### PR TITLE
Fix SQL*Plus compatibility issues in index creation script

### DIFF
--- a/index_creation.sql
+++ b/index_creation.sql
@@ -29,8 +29,8 @@
 
 
 /* ----- optional: make re-runs easier ----- */
-SET SERVEROUTPUT ON
-WHENEVER SQLERROR EXIT SQL.SQLCODE
+-- SET SERVEROUTPUT ON           -- SQL*Plus only; not valid in oracledb
+-- WHENEVER SQLERROR EXIT SQL.SQLCODE  -- SQL*Plus only; not valid in oracledb
 
 /* ============================================================================ */
 /*  0) DROP objects (ignore if missing)                                           */
@@ -62,6 +62,7 @@ CREATE TABLE all_objects_search_text (
   column_summary CLOB,
   dummy          CHAR(1) DEFAULT 'X' NOT NULL
 );
+/
 
 CREATE TABLE all_cols_search_text (
   object_id      NUMBER NOT NULL,
@@ -76,6 +77,7 @@ CREATE TABLE all_cols_search_text (
   CONSTRAINT all_cols_search_fk FOREIGN KEY (object_id)
     REFERENCES all_objects_search_text(object_id)
 );
+/
 
 /* ============================================================================ */
 /*  2) PACKAGE: DEVELOPER                                                         */
@@ -170,7 +172,7 @@ CREATE OR REPLACE PACKAGE developer AUTHID CURRENT_USER AS
   );
 END developer;
 /
-SHOW ERRORS
+-- SHOW ERRORS  -- SQL*Plus only; not valid in oracledb
 
 CREATE OR REPLACE PACKAGE BODY developer AS
 
@@ -727,7 +729,7 @@ CREATE OR REPLACE PACKAGE BODY developer AS
 
 END developer;
 /
-SHOW ERRORS
+-- SHOW ERRORS  -- SQL*Plus only; not valid in oracledb
 
 /* ============================================================================ */
 /*  3) OPTIONAL: Example execution (uncomment to run)                            */

--- a/run_hybrid_search_evaluation.py
+++ b/run_hybrid_search_evaluation.py
@@ -26,6 +26,7 @@ import argparse
 import csv
 import json
 import os
+import re
 import sys
 import time
 from dataclasses import dataclass, field
@@ -493,29 +494,67 @@ class OracleManager:
 
             cursor = self.user_connection.cursor()
 
+            # Strip SQL*Plus-specific commands (not valid via oracledb)
+            sql_content = re.sub(r'(?m)^\s*SET\s+SERVEROUTPUT\s+.*$', '', sql_content)
+            sql_content = re.sub(r'(?m)^\s*WHENEVER\s+SQLERROR\s+.*$', '', sql_content)
+            sql_content = re.sub(r'(?m)^\s*SHOW\s+ERRORS\s*$', '', sql_content)
+
             # Split PL/SQL content by '/' delimiter (standard for PL/SQL scripts)
             # Each block (package spec, package body) is typically separated by '/'
             blocks = sql_content.split('\n/\n')
 
+            plsql_keywords = ['CREATE OR REPLACE PACKAGE',
+                              'CREATE OR REPLACE PROCEDURE',
+                              'CREATE OR REPLACE FUNCTION',
+                              'BEGIN', 'DECLARE']
+
             for block in blocks:
                 block = block.strip()
-                if block and not block.startswith('--'):
-                    # Skip pure comment blocks or empty blocks
-                    # Check if it's a PL/SQL block or regular SQL
-                    if any(kw in block.upper() for kw in ['CREATE OR REPLACE PACKAGE',
-                                                           'CREATE OR REPLACE PROCEDURE',
-                                                           'CREATE OR REPLACE FUNCTION',
-                                                           'BEGIN', 'DECLARE']):
-                        cursor.execute(block)
-                    elif block.strip().upper().startswith('SELECT'):
-                        # Skip standalone SELECT statements (likely placeholders)
-                        continue
-                    else:
-                        # Try to execute as regular SQL
-                        try:
-                            cursor.execute(block)
-                        except oracledb.DatabaseError:
-                            pass  # Ignore errors for non-essential statements
+                if not block or block.startswith('--'):
+                    continue
+
+                upper_block = block.upper()
+
+                # Check if it's a PL/SQL block or regular SQL
+                if any(kw in upper_block for kw in plsql_keywords):
+                    # Find where the PL/SQL part starts (there may be
+                    # standalone DDL like CREATE TABLE before it)
+                    plsql_start = len(block)
+                    for kw in plsql_keywords:
+                        idx = upper_block.find(kw)
+                        if idx != -1 and idx < plsql_start:
+                            plsql_start = idx
+
+                    # Execute any DDL statements that precede the PL/SQL block
+                    pre_plsql = block[:plsql_start].strip()
+                    if pre_plsql:
+                        for stmt in pre_plsql.split(';'):
+                            stmt = stmt.strip()
+                            # Remove comments to check if there's actual SQL
+                            cleaned = re.sub(r'/\*.*?\*/', '', stmt, flags=re.DOTALL)
+                            cleaned = re.sub(r'--.*$', '', cleaned, flags=re.MULTILINE).strip()
+                            if cleaned:
+                                try:
+                                    cursor.execute(stmt)
+                                except oracledb.DatabaseError as e:
+                                    print(f"    Warning: DDL statement failed: {e}")
+
+                    # Execute the PL/SQL block itself
+                    plsql_part = block[plsql_start:].strip()
+                    if plsql_part:
+                        cursor.execute(plsql_part)
+
+                elif upper_block.lstrip().startswith('SELECT'):
+                    # Skip standalone SELECT statements (likely placeholders)
+                    continue
+                else:
+                    # Try to execute as regular SQL (strip trailing ; for DDL)
+                    try:
+                        sql = block.rstrip().rstrip(';').rstrip()
+                        if sql:
+                            cursor.execute(sql)
+                    except oracledb.DatabaseError:
+                        pass  # Ignore errors for non-essential statements
 
             self.user_connection.commit()
             print(f"    Executed index creation script")


### PR DESCRIPTION
## Summary
Updated the index creation script and its execution handler to remove SQL*Plus-specific commands that are incompatible with the oracledb Python driver, and improved PL/SQL block parsing to correctly handle mixed DDL and PL/SQL statements.

## Key Changes

**index_creation.sql:**
- Commented out `SET SERVEROUTPUT ON` and `WHENEVER SQLERROR EXIT SQL.SQLCODE` commands with explanatory notes (SQL*Plus only)
- Commented out `SHOW ERRORS` commands after package creation (SQL*Plus only)
- Added forward slash (`/`) statement terminators after table creation statements for proper PL/SQL block separation

**run_hybrid_search_evaluation.py:**
- Added regex-based stripping of SQL*Plus-specific commands (`SET`, `WHENEVER`, `SHOW ERRORS`) before script execution
- Improved block parsing logic to:
  - Separate DDL statements that precede PL/SQL blocks
  - Execute DDL statements individually with error handling
  - Execute PL/SQL blocks as complete units
  - Better handle comment removal and statement validation
- Refactored keyword detection into a reusable list for maintainability
- Enhanced error handling with informative warning messages for failed DDL statements

## Implementation Details
The parser now correctly handles scripts where DDL statements (like `CREATE TABLE`) appear in the same block as PL/SQL code. It identifies the start of PL/SQL keywords, executes any preceding DDL separately, then executes the PL/SQL block as a single unit. This ensures proper execution order and allows individual statement failures to be handled appropriately.

https://claude.ai/code/session_01QQWtH3aTKGhaYi5EaZ1xG6