### PR TITLE
Add DiscoveryConfig, CLI discovery group, and @k precision/recall/F1 metrics (table+column)

### DIFF
--- a/HYBRID_SEARCH_EVALUATION.md
+++ b/HYBRID_SEARCH_EVALUATION.md
@@ -180,6 +180,24 @@ Then open `http://localhost:8000/report.html` in your browser.
 | `--port` | | 8000 | Port for the local HTTP server |
 | `--single-user-mode` | | false | Load all selected schemas into one Oracle user and run all queries there |
 | `--single-user-name` | | `BIRD_ALL` | Username for `--single-user-mode` (password is the same as username) |
+| `--parallel-discovery` | | false | Use `developer.discover_objects_parallel()` instead of sequential discover |
+
+### Discovery Argument Group
+
+You can now provide discovery procedure arguments as a grouped JSON config and/or explicit overrides.
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--discover-config-json` | none | JSON blob for discovery args. Example: `{"k":10,"k0":50,"n":null,"m":null,"cols_per_obj":5,"alpha":0.65,"parallel_alpha":0.60}` |
+| `--discover-k` | 10 | Final top-K objects returned and metric cutoff K |
+| `--discover-k0` | 50 | Sequential stage-1 object topN (`p_k0`) |
+| `--discover-n` | null | Sequential stage-2 column topN (`p_n`) |
+| `--discover-m` | null | Parallel column topN (`p_m`) |
+| `--discover-cols-per-obj` | 5 | Max columns attached per object |
+| `--discover-alpha` | 0.65 | Sequential rerank blend alpha (`p_alpha`) |
+| `--discover-parallel-alpha` | 0.60 | Parallel rerank blend alpha (`p_alpha`) |
+
+Override precedence: explicit CLI flags > `--discover-config-json` > built-in defaults.
 
 ## Output Files
 
@@ -508,3 +526,14 @@ Overall Hit@1 rate: 55.00%
 ## License
 
 Part of the BIRD Oracle benchmark evaluation project.
+
+
+## Additional @K Metrics (Table + Column)
+
+The evaluator now reports these ranked-cutoff metrics in **results CSV**, **summary CSV**, and the **HTML dashboard**:
+
+- Recall@3, Recall@5, Recall@K
+- Precision@1, Precision@3, Precision@5, Precision@K
+- F1@1, F1@3, F1@5, F1@K
+
+These are emitted for both table and column signals, and database-level averages are included in summary output.

--- a/README.md
+++ b/README.md
@@ -173,3 +173,19 @@ Options:
 
 - Python 3.6+
 - No external dependencies (uses only standard library)
+
+
+## Hybrid Search Evaluation
+
+Use `run_hybrid_search_evaluation.py` for Oracle hybrid discovery benchmarking with sequential or parallel discovery modes.
+
+Example with parallel mode and grouped discovery config:
+
+```bash
+python run_hybrid_search_evaluation.py \
+  --connection-string "sys/password@localhost:1521/FREEPDB1" \
+  --parallel-discovery \
+  --discover-config-json '{"k":10,"m":80,"cols_per_obj":5,"parallel_alpha":0.60}'
+```
+
+The generated HTML/CSV reports include additional @K metrics (Recall, Precision, F1) for both table and column evaluation.

--- a/index_creation.sql
+++ b/index_creation.sql
@@ -173,6 +173,35 @@ CREATE OR REPLACE PACKAGE developer AUTHID CURRENT_USER AS
     p_alpha         IN  NUMBER      DEFAULT 0.65,
     p_result_json   OUT JSON
   );
+
+-------------------------------------------------------------------------------
+-- DISCOVER_OBJECTS_PARALLEL: NL metadata discovery using parallel hybrid search.
+--
+-- STRATEGY:
+--   1) Run hybrid object search on ALL_OBJECTS_SEARCH_TEXT (top p_k)
+--   2) Run hybrid column search on ALL_COLS_SEARCH_TEXT (top p_m, default p_k*5)
+--   3) Group column hits by object_id and retain per-column scores
+--   4) Normalize object/column scores and rerank merged candidates
+--   5) Output top p_k objects as JSON array
+--
+-- PARAMETERS:
+--   p_query          - Natural language query text (CLOB)
+--   p_hints          - Optional text hints (object/schema regex text query)
+--   p_k              - Top-N final objects
+--   p_m              - Column hit budget, must be > p_k (default p_k*5)
+--   p_cols_per_obj   - Max columns attached per object in output
+--   p_alpha          - Weight object evidence vs column evidence
+--   p_result_json    - OUT JSON result array
+-------------------------------------------------------------------------------
+  PROCEDURE discover_objects_parallel(
+    p_query         IN  CLOB,
+    p_hints         IN  CLOB DEFAULT NULL,
+    p_k             IN  PLS_INTEGER DEFAULT 10,
+    p_m             IN  PLS_INTEGER DEFAULT NULL,
+    p_cols_per_obj  IN  PLS_INTEGER DEFAULT 3,
+    p_alpha         IN  NUMBER      DEFAULT 0.60,
+    p_result_json   OUT JSON
+  );
 END developer;
 /
 
@@ -475,6 +504,7 @@ CREATE OR REPLACE PACKAGE BODY developer AS
     l_counts t_count_tab;
     l_best   t_best_tab;
 
+    -- Keeps blended/normalized scores in [0,1] range for stable reranking/output
     FUNCTION clamp01(p_x NUMBER) RETURN NUMBER IS
     BEGIN
       IF p_x < 0 THEN RETURN 0; END IF;
@@ -600,6 +630,7 @@ CREATE OR REPLACE PACKAGE BODY developer AS
       l_cols(l_cols.COUNT).data_type     := r.data_type;
       l_cols(l_cols.COUNT).col_score_raw := r.col_score_raw;
 
+      -- Track min/max raw column scores to later normalize col_score_raw into [0,1].
       IF l_min_col IS NULL OR r.col_score_raw < l_min_col THEN l_min_col := r.col_score_raw; END IF;
       IF l_max_col IS NULL OR r.col_score_raw > l_max_col THEN l_max_col := r.col_score_raw; END IF;
     END LOOP;
@@ -730,6 +761,331 @@ CREATE OR REPLACE PACKAGE BODY developer AS
     END;
 
   END discover_objects;
+
+  /* ======================================================================== */
+  /* DISCOVER_OBJECTS_PARALLEL                                                */
+  /* ======================================================================== */
+  PROCEDURE discover_objects_parallel(
+    p_query         IN  CLOB,
+    p_hints         IN  CLOB DEFAULT NULL,
+    p_k             IN  PLS_INTEGER DEFAULT 10,
+    p_m             IN  PLS_INTEGER DEFAULT NULL,
+    p_cols_per_obj  IN  PLS_INTEGER DEFAULT 3,
+    p_alpha         IN  NUMBER      DEFAULT 0.60,
+    p_result_json   OUT JSON
+  ) IS
+    c_obj_index CONSTANT VARCHAR2(128) := 'DISCOVERY_INDEX';
+    c_col_index CONSTANT VARCHAR2(128) := 'COL_DISCOVERY_HVIX';
+
+    l_k PLS_INTEGER := GREATEST(1, NVL(p_k, 10));
+    l_m PLS_INTEGER := GREATEST(l_k + 1, NVL(p_m, l_k * 5));
+
+    l_obj_res CLOB;
+    l_col_res CLOB;
+
+    l_min_obj NUMBER := NULL;
+    l_max_obj NUMBER := NULL;
+    l_min_col NUMBER := NULL;
+    l_max_col NUMBER := NULL;
+
+    TYPE t_obj_rec IS RECORD (
+      object_id     NUMBER,
+      object_name   VARCHAR2(128),
+      owner         VARCHAR2(128),
+      object_type   VARCHAR2(23),
+      obj_score_raw NUMBER,
+      obj_norm      NUMBER,
+      col_support   NUMBER,
+      final_score   NUMBER
+    );
+    TYPE t_obj_tab IS TABLE OF t_obj_rec;
+    l_objs t_obj_tab := t_obj_tab();
+
+    TYPE t_col_rec IS RECORD (
+      object_id     NUMBER,
+      column_name   VARCHAR2(128),
+      data_type     VARCHAR2(128),
+      col_score_raw NUMBER,
+      col_norm      NUMBER
+    );
+    TYPE t_col_tab IS TABLE OF t_col_rec;
+    l_cols t_col_tab := t_col_tab();
+
+    TYPE t_objid_to_idx IS TABLE OF PLS_INTEGER INDEX BY VARCHAR2(64);
+    l_obj_map t_objid_to_idx;
+
+    TYPE t_top_cols  IS TABLE OF t_col_rec INDEX BY PLS_INTEGER;
+    TYPE t_count_tab IS TABLE OF PLS_INTEGER INDEX BY PLS_INTEGER;
+    TYPE t_best_tab  IS TABLE OF t_top_cols INDEX BY PLS_INTEGER;
+    l_counts t_count_tab;
+    l_best   t_best_tab;
+
+    -- Keep normalized/blended scores bounded in [0,1] for stable ranking
+    FUNCTION clamp01(p_x NUMBER) RETURN NUMBER IS
+    BEGIN
+      IF p_x < 0 THEN RETURN 0; END IF;
+      IF p_x > 1 THEN RETURN 1; END IF;
+      RETURN p_x;
+    END;
+  BEGIN
+    p_result_json := JSON('[]');
+    IF p_query IS NULL OR DBMS_LOB.getlength(p_query) = 0 THEN
+      RETURN;
+    END IF;
+
+    /* ---- Stage 1: object hybrid search ---- */
+    DECLARE
+      req         JSON_OBJECT_T := JSON_OBJECT_T();
+      ret_obj     JSON_OBJECT_T := JSON_OBJECT_T();
+      return_vals JSON_ARRAY_T  := JSON_ARRAY_T();
+    BEGIN
+      return_vals.append('rowid');
+      return_vals.append('score');
+      return_vals.append('vector_score');
+      return_vals.append('chunk_text');
+      return_vals.append('chunk_id');
+
+      ret_obj.put('values', return_vals);
+      ret_obj.put('topN', l_k);
+
+      req.put('hybrid_index_name', c_obj_index);
+      req.put('search_text', p_query);
+      IF p_hints IS NOT NULL AND DBMS_LOB.getlength(p_hints) > 0 THEN
+        req.put('contains', p_hints);
+      END IF;
+      req.put('return', ret_obj);
+
+      l_obj_res := DBMS_HYBRID_VECTOR.SEARCH(req.to_json);
+    END;
+
+    FOR r IN (
+      SELECT
+        o.object_id,
+        o.object_name,
+        o.owner,
+        o.object_type,
+        jt.score AS obj_score_raw
+      FROM JSON_TABLE(
+             l_obj_res,
+             '$[*]'
+             COLUMNS (
+               rowid_txt VARCHAR2(200) PATH '$.rowid',
+               score     NUMBER        PATH '$.score'
+             )
+           ) jt
+      JOIN all_objects_search_text o
+        ON o.rowid = CHARTOROWID(jt.rowid_txt)
+    ) LOOP
+      l_objs.EXTEND;
+      l_objs(l_objs.COUNT).object_id     := r.object_id;
+      l_objs(l_objs.COUNT).object_name   := r.object_name;
+      l_objs(l_objs.COUNT).owner         := r.owner;
+      l_objs(l_objs.COUNT).object_type   := r.object_type;
+      l_objs(l_objs.COUNT).obj_score_raw := r.obj_score_raw;
+      l_obj_map(TO_CHAR(r.object_id)) := l_objs.COUNT;
+
+      IF l_min_obj IS NULL OR r.obj_score_raw < l_min_obj THEN l_min_obj := r.obj_score_raw; END IF;
+      IF l_max_obj IS NULL OR r.obj_score_raw > l_max_obj THEN l_max_obj := r.obj_score_raw; END IF;
+    END LOOP;
+
+    /* ---- Stage 2: column hybrid search ---- */
+    DECLARE
+      req         JSON_OBJECT_T := JSON_OBJECT_T();
+      ret_obj     JSON_OBJECT_T := JSON_OBJECT_T();
+      return_vals JSON_ARRAY_T  := JSON_ARRAY_T();
+    BEGIN
+      return_vals.append('rowid');
+      return_vals.append('score');
+      return_vals.append('vector_score');
+      return_vals.append('chunk_text');
+      return_vals.append('chunk_id');
+
+      ret_obj.put('values', return_vals);
+      ret_obj.put('topN', l_m);
+
+      req.put('hybrid_index_name', c_col_index);
+      req.put('search_text', p_query);
+      IF p_hints IS NOT NULL AND DBMS_LOB.getlength(p_hints) > 0 THEN
+        req.put('contains', p_hints);
+      END IF;
+      req.put('return', ret_obj);
+
+      l_col_res := DBMS_HYBRID_VECTOR.SEARCH(req.to_json);
+    END;
+
+    FOR r IN (
+      SELECT
+        c.object_id,
+        c.column_name,
+        c.data_type,
+        jt.score AS col_score_raw
+      FROM JSON_TABLE(
+             l_col_res,
+             '$[*]'
+             COLUMNS (
+               rowid_txt VARCHAR2(200) PATH '$.rowid',
+               score     NUMBER        PATH '$.score'
+             )
+           ) jt
+      JOIN all_cols_search_text c
+        ON c.rowid = CHARTOROWID(jt.rowid_txt)
+    ) LOOP
+      l_cols.EXTEND;
+      l_cols(l_cols.COUNT).object_id     := r.object_id;
+      l_cols(l_cols.COUNT).column_name   := r.column_name;
+      l_cols(l_cols.COUNT).data_type     := r.data_type;
+      l_cols(l_cols.COUNT).col_score_raw := r.col_score_raw;
+
+      -- Track min/max raw column scores so we can normalize each hit later.
+      IF l_min_col IS NULL OR r.col_score_raw < l_min_col THEN l_min_col := r.col_score_raw; END IF;
+      IF l_max_col IS NULL OR r.col_score_raw > l_max_col THEN l_max_col := r.col_score_raw; END IF;
+    END LOOP;
+
+    IF l_objs.COUNT = 0 AND l_cols.COUNT = 0 THEN
+      RETURN;
+    END IF;
+
+    IF l_cols.COUNT > 0 THEN
+      FOR i IN 1 .. l_cols.COUNT LOOP
+        IF NOT l_obj_map.EXISTS(TO_CHAR(l_cols(i).object_id)) THEN
+          l_objs.EXTEND;
+          SELECT object_id, object_name, owner, object_type
+            INTO l_objs(l_objs.COUNT).object_id,
+                 l_objs(l_objs.COUNT).object_name,
+                 l_objs(l_objs.COUNT).owner,
+                 l_objs(l_objs.COUNT).object_type
+            FROM all_objects_search_text
+           WHERE object_id = l_cols(i).object_id;
+
+          l_objs(l_objs.COUNT).obj_score_raw := l_min_obj;
+          l_obj_map(TO_CHAR(l_cols(i).object_id)) := l_objs.COUNT;
+        END IF;
+      END LOOP;
+    END IF;
+
+    FOR i IN 1 .. l_objs.COUNT LOOP
+      l_objs(i).obj_norm :=
+        CASE
+          WHEN l_min_obj IS NULL OR l_max_obj IS NULL OR l_max_obj = l_min_obj THEN 1
+          ELSE (l_objs(i).obj_score_raw - l_min_obj) / (l_max_obj - l_min_obj)
+        END;
+      l_objs(i).obj_norm := clamp01(l_objs(i).obj_norm);
+      l_counts(i) := 0;
+    END LOOP;
+
+    IF l_cols.COUNT > 0 THEN
+      FOR i IN 1 .. l_cols.COUNT LOOP
+        l_cols(i).col_norm :=
+          CASE
+            WHEN l_min_col IS NULL OR l_max_col IS NULL OR l_max_col = l_min_col THEN 1
+            ELSE (l_cols(i).col_score_raw - l_min_col) / (l_max_col - l_min_col)
+          END;
+        l_cols(i).col_norm := clamp01(l_cols(i).col_norm);
+      END LOOP;
+    END IF;
+
+    FOR i IN 1 .. l_cols.COUNT LOOP
+      DECLARE
+        obj_idx PLS_INTEGER;
+        tmp     t_col_rec;
+        j       PLS_INTEGER;
+      BEGIN
+        obj_idx := l_obj_map(TO_CHAR(l_cols(i).object_id));
+        IF obj_idx IS NULL THEN CONTINUE; END IF;
+
+        tmp := l_cols(i);
+        IF l_counts(obj_idx) < p_cols_per_obj THEN
+          l_counts(obj_idx) := l_counts(obj_idx) + 1;
+          l_best(obj_idx)(l_counts(obj_idx)) := tmp;
+        ELSE
+          IF tmp.col_norm > l_best(obj_idx)(l_counts(obj_idx)).col_norm THEN
+            l_best(obj_idx)(l_counts(obj_idx)) := tmp;
+          ELSE
+            CONTINUE;
+          END IF;
+        END IF;
+
+        FOR j IN REVERSE 2 .. l_counts(obj_idx) LOOP
+          IF l_best(obj_idx)(j).col_norm > l_best(obj_idx)(j-1).col_norm THEN
+            tmp := l_best(obj_idx)(j-1);
+            l_best(obj_idx)(j-1) := l_best(obj_idx)(j);
+            l_best(obj_idx)(j) := tmp;
+          END IF;
+        END LOOP;
+      END;
+    END LOOP;
+
+    FOR i IN 1 .. l_objs.COUNT LOOP
+      IF l_counts(i) IS NULL OR l_counts(i) = 0 THEN
+        l_objs(i).col_support := 0;
+      ELSE
+        DECLARE
+          s NUMBER := 0;
+          m PLS_INTEGER := l_counts(i);
+        BEGIN
+          FOR j IN 1 .. m LOOP
+            s := s + l_best(i)(j).col_norm;
+          END LOOP;
+          l_objs(i).col_support := s / m;
+        END;
+      END IF;
+
+      l_objs(i).final_score :=
+        clamp01(p_alpha * l_objs(i).obj_norm + (1 - p_alpha) * l_objs(i).col_support);
+    END LOOP;
+
+    DECLARE
+      TYPE t_used_tab IS TABLE OF BOOLEAN INDEX BY PLS_INTEGER;
+      l_used t_used_tab;
+      out_arr JSON_ARRAY_T := JSON_ARRAY_T();
+      best_i  PLS_INTEGER;
+      best_s  NUMBER;
+    BEGIN
+      FOR pick IN 1 .. LEAST(l_k, l_objs.COUNT) LOOP
+        best_i := NULL;
+        best_s := -1;
+
+        FOR i IN 1 .. l_objs.COUNT LOOP
+          IF l_used.EXISTS(i) AND l_used(i) THEN CONTINUE; END IF;
+          IF l_objs(i).final_score > best_s THEN
+            best_s := l_objs(i).final_score;
+            best_i := i;
+          END IF;
+        END LOOP;
+
+        EXIT WHEN best_i IS NULL;
+        l_used(best_i) := TRUE;
+
+        DECLARE
+          o JSON_OBJECT_T := JSON_OBJECT_T();
+          cols JSON_ARRAY_T := JSON_ARRAY_T();
+        BEGIN
+          o.put('objectName', l_objs(best_i).object_name);
+          o.put('objectType', l_objs(best_i).object_type);
+          o.put('schema',     l_objs(best_i).owner);
+          o.put('score',      ROUND(l_objs(best_i).final_score, 6));
+
+          IF l_counts(best_i) IS NOT NULL AND l_counts(best_i) > 0 THEN
+            FOR j IN 1 .. l_counts(best_i) LOOP
+              DECLARE
+                c JSON_OBJECT_T := JSON_OBJECT_T();
+              BEGIN
+                c.put('name',     l_best(best_i)(j).column_name);
+                c.put('dataType', l_best(best_i)(j).data_type);
+                c.put('score',    ROUND(l_best(best_i)(j).col_norm, 6));
+                cols.append(c);
+              END;
+            END LOOP;
+            o.put('columns', cols);
+          END IF;
+
+          out_arr.append(o);
+        END;
+      END LOOP;
+
+      p_result_json := out_arr.to_json;
+    END;
+  END discover_objects_parallel;
 
 END developer;
 /

--- a/run_hybrid_search_evaluation.py
+++ b/run_hybrid_search_evaluation.py
@@ -97,6 +97,18 @@ class ExpectedObject:
 
 
 @dataclass
+class DiscoveryConfig:
+    """Configurable discovery parameters used by PL/SQL discovery procedures."""
+    k: int = 10
+    k0: int = 50
+    n: Optional[int] = None
+    m: Optional[int] = None
+    cols_per_obj: int = 5
+    alpha: float = 0.65
+    parallel_alpha: float = 0.60
+
+
+@dataclass
 class EvaluationResult:
     """Stores evaluation metrics for a single query."""
     question_id: int
@@ -132,6 +144,28 @@ class EvaluationResult:
     table_recall_at_3: float = 0.0   # Fraction of expected tables in top-3
     table_recall_at_5: float = 0.0   # Fraction of expected tables in top-5
     table_recall_at_10: float = 0.0  # Fraction of expected tables in top-10
+    table_recall_at_k: float = 0.0
+    column_recall_at_3: float = 0.0
+    column_recall_at_5: float = 0.0
+    column_recall_at_k: float = 0.0
+
+    table_precision_at_1: float = 0.0
+    table_precision_at_3: float = 0.0
+    table_precision_at_5: float = 0.0
+    table_precision_at_k: float = 0.0
+    table_f1_at_1: float = 0.0
+    table_f1_at_3: float = 0.0
+    table_f1_at_5: float = 0.0
+    table_f1_at_k: float = 0.0
+
+    column_precision_at_1: float = 0.0
+    column_precision_at_3: float = 0.0
+    column_precision_at_5: float = 0.0
+    column_precision_at_k: float = 0.0
+    column_f1_at_1: float = 0.0
+    column_f1_at_3: float = 0.0
+    column_f1_at_5: float = 0.0
+    column_f1_at_k: float = 0.0
     table_mrr: float = 0.0           # Mean Reciprocal Rank
     table_exact_match: bool = False  # All expected tables found (no more, no less)
     table_jaccard: float = 0.0       # Jaccard similarity
@@ -173,6 +207,28 @@ class DatabaseSummary:
     avg_table_recall_at_3: float = 0.0
     avg_table_recall_at_5: float = 0.0
     avg_table_recall_at_10: float = 0.0
+    avg_table_recall_at_k: float = 0.0
+    avg_column_recall_at_3: float = 0.0
+    avg_column_recall_at_5: float = 0.0
+    avg_column_recall_at_k: float = 0.0
+
+    avg_table_precision_at_1: float = 0.0
+    avg_table_precision_at_3: float = 0.0
+    avg_table_precision_at_5: float = 0.0
+    avg_table_precision_at_k: float = 0.0
+    avg_table_f1_at_1: float = 0.0
+    avg_table_f1_at_3: float = 0.0
+    avg_table_f1_at_5: float = 0.0
+    avg_table_f1_at_k: float = 0.0
+
+    avg_column_precision_at_1: float = 0.0
+    avg_column_precision_at_3: float = 0.0
+    avg_column_precision_at_5: float = 0.0
+    avg_column_precision_at_k: float = 0.0
+    avg_column_f1_at_1: float = 0.0
+    avg_column_f1_at_3: float = 0.0
+    avg_column_f1_at_5: float = 0.0
+    avg_column_f1_at_k: float = 0.0
     avg_table_mrr: float = 0.0
     table_exact_match_rate: float = 0.0
     avg_table_jaccard: float = 0.0
@@ -586,7 +642,10 @@ class OracleManager:
             return False
 
     def discover_objects(self, query: str, k: int = 10, k0: int = 50,
-                         cols_per_obj: int = 3) -> Tuple[Optional[List[DiscoveredObject]], float]:
+                         cols_per_obj: int = 3, use_parallel: bool = False,
+                         hints: Optional[str] = None, n: Optional[int] = None,
+                         m: Optional[int] = None, alpha: float = 0.65,
+                         parallel_alpha: float = 0.60) -> Tuple[Optional[List[DiscoveredObject]], float]:
         """
         Call developer.discover_objects() and return results.
 
@@ -595,6 +654,12 @@ class OracleManager:
             k: Final number of objects to return
             k0: Stage-1 candidate objects
             cols_per_obj: Max columns per object
+            use_parallel: If True, call developer.discover_objects_parallel()
+            hints: Optional hints string used by parallel discovery
+            n: Optional topN for stage-2 (sequential discover_objects p_n)
+            m: Optional topN for column search (parallel discover_objects_parallel p_m)
+            alpha: Weight for sequential rerank
+            parallel_alpha: Weight for parallel rerank
 
         Returns:
             Tuple of (list of discovered objects, execution time in ms)
@@ -611,15 +676,26 @@ class OracleManager:
             start_time = time.perf_counter()
 
             # Call the procedure
-            cursor.callproc('developer.discover_objects', [
-                query,      # p_query
-                k,          # p_k
-                k0,         # p_k0
-                None,       # p_n (default)
-                cols_per_obj,  # p_cols_per_obj
-                0.65,       # p_alpha (default)
-                result_json # p_result_json (OUT)
-            ])
+            if use_parallel:
+                cursor.callproc('developer.discover_objects_parallel', [
+                    query,          # p_query
+                    hints,          # p_hints
+                    k,              # p_k
+                    m,              # p_m
+                    cols_per_obj,   # p_cols_per_obj
+                    parallel_alpha, # p_alpha
+                    result_json     # p_result_json (OUT)
+                ])
+            else:
+                cursor.callproc('developer.discover_objects', [
+                    query,      # p_query
+                    k,          # p_k
+                    k0,         # p_k0
+                    n,          # p_n
+                    cols_per_obj,  # p_cols_per_obj
+                    alpha,      # p_alpha
+                    result_json # p_result_json (OUT)
+                ])
 
             end_time = time.perf_counter()
             execution_time_ms = (end_time - start_time) * 1000
@@ -640,8 +716,11 @@ class OracleManager:
                         schema=item.get('schema', ''),
                         score=item.get('score', 0.0),
                         columns=[
-                            {'name': c.get('name', ''), 'datatype': c.get('datatype', '')}
-                            for c in item.get('column', [])
+                            {
+                                'name': c.get('name', ''),
+                                'datatype': c.get('datatype', c.get('dataType', ''))
+                            }
+                            for c in item.get('column', item.get('columns', []))
                         ]
                     )
                     discovered.append(obj)
@@ -820,6 +899,20 @@ def calculate_recall_at_k(expected: Set[str], discovered: List[str], k: int) -> 
 
     found = len(expected_lower & top_k_lower)
     return found / len(expected_lower)
+
+
+def calculate_precision_recall_f1_at_k(expected: Set[str], discovered: List[str], k: int) -> Tuple[float, float, float]:
+    """Calculate Precision@k, Recall@k, and F1@k using ordered discovered list."""
+    expected_lower = {e.lower() for e in expected}
+    if not expected_lower:
+        return 0.0, 0.0, 0.0
+
+    top_k_lower = {d.lower() for d in discovered[:k]}
+    tp = len(expected_lower & top_k_lower)
+    precision = tp / len(top_k_lower) if top_k_lower else 0.0
+    recall = tp / len(expected_lower)
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) > 0 else 0.0
+    return precision, recall, f1
 
 
 def calculate_mrr(expected: Set[str], discovered: List[str]) -> float:
@@ -1007,7 +1100,8 @@ def calculate_topn_accuracy(
 
 
 def evaluate_result(expected_tables: List[ExpectedObject],
-                   discovered: List[DiscoveredObject]) -> Dict:
+                   discovered: List[DiscoveredObject],
+                   eval_k: int = 10) -> Dict:
     """
     Evaluate discovered objects against expected.
 
@@ -1027,9 +1121,16 @@ def evaluate_result(expected_tables: List[ExpectedObject],
     # Extract discovered table names and columns
     discovered_table_names = [d.object_name for d in discovered]
     discovered_column_names = set()
+    discovered_column_ordered = []
+    seen_cols = set()
     for d in discovered:
         for col in d.columns:
-            discovered_column_names.add(col['name'])
+            col_name = col['name']
+            discovered_column_names.add(col_name)
+            c_lower = col_name.lower()
+            if c_lower not in seen_cols:
+                seen_cols.add(c_lower)
+                discovered_column_ordered.append(col_name)
 
     # Basic metrics (Precision, Recall, F1)
     table_p, table_r, table_f1 = calculate_precision_recall_f1(
@@ -1049,6 +1150,17 @@ def evaluate_result(expected_tables: List[ExpectedObject],
     recall_at_3 = calculate_recall_at_k(expected_table_names, discovered_table_names, 3)
     recall_at_5 = calculate_recall_at_k(expected_table_names, discovered_table_names, 5)
     recall_at_10 = calculate_recall_at_k(expected_table_names, discovered_table_names, 10)
+    recall_at_k = calculate_recall_at_k(expected_table_names, discovered_table_names, eval_k)
+
+    table_p_at_1, _, table_f1_at_1 = calculate_precision_recall_f1_at_k(expected_table_names, discovered_table_names, 1)
+    table_p_at_3, _, table_f1_at_3 = calculate_precision_recall_f1_at_k(expected_table_names, discovered_table_names, 3)
+    table_p_at_5, _, table_f1_at_5 = calculate_precision_recall_f1_at_k(expected_table_names, discovered_table_names, 5)
+    table_p_at_k, _, table_f1_at_k = calculate_precision_recall_f1_at_k(expected_table_names, discovered_table_names, eval_k)
+
+    col_p_at_1, col_r_at_1, col_f1_at_1 = calculate_precision_recall_f1_at_k(expected_column_names, discovered_column_ordered, 1)
+    col_p_at_3, col_r_at_3, col_f1_at_3 = calculate_precision_recall_f1_at_k(expected_column_names, discovered_column_ordered, 3)
+    col_p_at_5, col_r_at_5, col_f1_at_5 = calculate_precision_recall_f1_at_k(expected_column_names, discovered_column_ordered, 5)
+    col_p_at_k, col_r_at_k, col_f1_at_k = calculate_precision_recall_f1_at_k(expected_column_names, discovered_column_ordered, eval_k)
 
     # MRR (ranking quality)
     mrr = calculate_mrr(expected_table_names, discovered_table_names)
@@ -1103,6 +1215,28 @@ def evaluate_result(expected_tables: List[ExpectedObject],
         'recall_at_3': recall_at_3,
         'recall_at_5': recall_at_5,
         'recall_at_10': recall_at_10,
+        'recall_at_k': recall_at_k,
+
+        'table_precision_at_1': table_p_at_1,
+        'table_precision_at_3': table_p_at_3,
+        'table_precision_at_5': table_p_at_5,
+        'table_precision_at_k': table_p_at_k,
+        'table_f1_at_1': table_f1_at_1,
+        'table_f1_at_3': table_f1_at_3,
+        'table_f1_at_5': table_f1_at_5,
+        'table_f1_at_k': table_f1_at_k,
+
+        'column_recall_at_3': col_r_at_3,
+        'column_recall_at_5': col_r_at_5,
+        'column_recall_at_k': col_r_at_k,
+        'column_precision_at_1': col_p_at_1,
+        'column_precision_at_3': col_p_at_3,
+        'column_precision_at_5': col_p_at_5,
+        'column_precision_at_k': col_p_at_k,
+        'column_f1_at_1': col_f1_at_1,
+        'column_f1_at_3': col_f1_at_3,
+        'column_f1_at_5': col_f1_at_5,
+        'column_f1_at_k': col_f1_at_k,
 
         # Advanced metrics
         'mrr': mrr,
@@ -1197,6 +1331,12 @@ def write_results_csv(results: List[EvaluationResult], filepath: str):
         'table_hit_at_1', 'table_hit_at_3', 'table_hit_at_5',
         # Recall@k (fraction - better for multi-table)
         'table_recall_at_3', 'table_recall_at_5', 'table_recall_at_10',
+        'table_recall_at_k',
+        'column_recall_at_3', 'column_recall_at_5', 'column_recall_at_k',
+        'table_precision_at_1', 'table_precision_at_3', 'table_precision_at_5', 'table_precision_at_k',
+        'table_f1_at_1', 'table_f1_at_3', 'table_f1_at_5', 'table_f1_at_k',
+        'column_precision_at_1', 'column_precision_at_3', 'column_precision_at_5', 'column_precision_at_k',
+        'column_f1_at_1', 'column_f1_at_3', 'column_f1_at_5', 'column_f1_at_k',
         # Advanced metrics
         'table_mrr', 'table_jaccard', 'table_exact_match',
         # Joint table-column metrics
@@ -1237,6 +1377,26 @@ def write_results_csv(results: List[EvaluationResult], filepath: str):
                 'table_recall_at_3': f"{result.table_recall_at_3:.4f}",
                 'table_recall_at_5': f"{result.table_recall_at_5:.4f}",
                 'table_recall_at_10': f"{result.table_recall_at_10:.4f}",
+                'table_recall_at_k': f"{result.table_recall_at_k:.4f}",
+                'column_recall_at_3': f"{result.column_recall_at_3:.4f}",
+                'column_recall_at_5': f"{result.column_recall_at_5:.4f}",
+                'column_recall_at_k': f"{result.column_recall_at_k:.4f}",
+                'table_precision_at_1': f"{result.table_precision_at_1:.4f}",
+                'table_precision_at_3': f"{result.table_precision_at_3:.4f}",
+                'table_precision_at_5': f"{result.table_precision_at_5:.4f}",
+                'table_precision_at_k': f"{result.table_precision_at_k:.4f}",
+                'table_f1_at_1': f"{result.table_f1_at_1:.4f}",
+                'table_f1_at_3': f"{result.table_f1_at_3:.4f}",
+                'table_f1_at_5': f"{result.table_f1_at_5:.4f}",
+                'table_f1_at_k': f"{result.table_f1_at_k:.4f}",
+                'column_precision_at_1': f"{result.column_precision_at_1:.4f}",
+                'column_precision_at_3': f"{result.column_precision_at_3:.4f}",
+                'column_precision_at_5': f"{result.column_precision_at_5:.4f}",
+                'column_precision_at_k': f"{result.column_precision_at_k:.4f}",
+                'column_f1_at_1': f"{result.column_f1_at_1:.4f}",
+                'column_f1_at_3': f"{result.column_f1_at_3:.4f}",
+                'column_f1_at_5': f"{result.column_f1_at_5:.4f}",
+                'column_f1_at_k': f"{result.column_f1_at_k:.4f}",
                 # Advanced metrics
                 'table_mrr': f"{result.table_mrr:.4f}",
                 'table_jaccard': f"{result.table_jaccard:.4f}",
@@ -1267,6 +1427,12 @@ def write_summary_csv(summaries: List[DatabaseSummary], filepath: str):
         'table_hit_at_1_rate', 'table_hit_at_3_rate', 'table_hit_at_5_rate',
         # Recall@k averages (fraction - better for multi-table)
         'avg_table_recall_at_3', 'avg_table_recall_at_5', 'avg_table_recall_at_10',
+        'avg_table_recall_at_k',
+        'avg_column_recall_at_3', 'avg_column_recall_at_5', 'avg_column_recall_at_k',
+        'avg_table_precision_at_1', 'avg_table_precision_at_3', 'avg_table_precision_at_5', 'avg_table_precision_at_k',
+        'avg_table_f1_at_1', 'avg_table_f1_at_3', 'avg_table_f1_at_5', 'avg_table_f1_at_k',
+        'avg_column_precision_at_1', 'avg_column_precision_at_3', 'avg_column_precision_at_5', 'avg_column_precision_at_k',
+        'avg_column_f1_at_1', 'avg_column_f1_at_3', 'avg_column_f1_at_5', 'avg_column_f1_at_k',
         # Advanced metrics
         'avg_table_mrr', 'avg_table_jaccard', 'table_exact_match_rate',
         # Joint table-column metrics
@@ -1301,6 +1467,26 @@ def write_summary_csv(summaries: List[DatabaseSummary], filepath: str):
                 'avg_table_recall_at_3': f"{summary.avg_table_recall_at_3:.4f}",
                 'avg_table_recall_at_5': f"{summary.avg_table_recall_at_5:.4f}",
                 'avg_table_recall_at_10': f"{summary.avg_table_recall_at_10:.4f}",
+                'avg_table_recall_at_k': f"{summary.avg_table_recall_at_k:.4f}",
+                'avg_column_recall_at_3': f"{summary.avg_column_recall_at_3:.4f}",
+                'avg_column_recall_at_5': f"{summary.avg_column_recall_at_5:.4f}",
+                'avg_column_recall_at_k': f"{summary.avg_column_recall_at_k:.4f}",
+                'avg_table_precision_at_1': f"{summary.avg_table_precision_at_1:.4f}",
+                'avg_table_precision_at_3': f"{summary.avg_table_precision_at_3:.4f}",
+                'avg_table_precision_at_5': f"{summary.avg_table_precision_at_5:.4f}",
+                'avg_table_precision_at_k': f"{summary.avg_table_precision_at_k:.4f}",
+                'avg_table_f1_at_1': f"{summary.avg_table_f1_at_1:.4f}",
+                'avg_table_f1_at_3': f"{summary.avg_table_f1_at_3:.4f}",
+                'avg_table_f1_at_5': f"{summary.avg_table_f1_at_5:.4f}",
+                'avg_table_f1_at_k': f"{summary.avg_table_f1_at_k:.4f}",
+                'avg_column_precision_at_1': f"{summary.avg_column_precision_at_1:.4f}",
+                'avg_column_precision_at_3': f"{summary.avg_column_precision_at_3:.4f}",
+                'avg_column_precision_at_5': f"{summary.avg_column_precision_at_5:.4f}",
+                'avg_column_precision_at_k': f"{summary.avg_column_precision_at_k:.4f}",
+                'avg_column_f1_at_1': f"{summary.avg_column_f1_at_1:.4f}",
+                'avg_column_f1_at_3': f"{summary.avg_column_f1_at_3:.4f}",
+                'avg_column_f1_at_5': f"{summary.avg_column_f1_at_5:.4f}",
+                'avg_column_f1_at_k': f"{summary.avg_column_f1_at_k:.4f}",
                 # Advanced metrics
                 'avg_table_mrr': f"{summary.avg_table_mrr:.4f}",
                 'avg_table_jaccard': f"{summary.avg_table_jaccard:.4f}",
@@ -1479,6 +1665,28 @@ def calculate_summary(db_id: str, results: List[EvaluationResult]) -> DatabaseSu
         summary.avg_table_recall_at_3 = sum(r.table_recall_at_3 for r in successful) / n
         summary.avg_table_recall_at_5 = sum(r.table_recall_at_5 for r in successful) / n
         summary.avg_table_recall_at_10 = sum(r.table_recall_at_10 for r in successful) / n
+        summary.avg_table_recall_at_k = sum(r.table_recall_at_k for r in successful) / n
+        summary.avg_column_recall_at_3 = sum(r.column_recall_at_3 for r in successful) / n
+        summary.avg_column_recall_at_5 = sum(r.column_recall_at_5 for r in successful) / n
+        summary.avg_column_recall_at_k = sum(r.column_recall_at_k for r in successful) / n
+
+        summary.avg_table_precision_at_1 = sum(r.table_precision_at_1 for r in successful) / n
+        summary.avg_table_precision_at_3 = sum(r.table_precision_at_3 for r in successful) / n
+        summary.avg_table_precision_at_5 = sum(r.table_precision_at_5 for r in successful) / n
+        summary.avg_table_precision_at_k = sum(r.table_precision_at_k for r in successful) / n
+        summary.avg_table_f1_at_1 = sum(r.table_f1_at_1 for r in successful) / n
+        summary.avg_table_f1_at_3 = sum(r.table_f1_at_3 for r in successful) / n
+        summary.avg_table_f1_at_5 = sum(r.table_f1_at_5 for r in successful) / n
+        summary.avg_table_f1_at_k = sum(r.table_f1_at_k for r in successful) / n
+
+        summary.avg_column_precision_at_1 = sum(r.column_precision_at_1 for r in successful) / n
+        summary.avg_column_precision_at_3 = sum(r.column_precision_at_3 for r in successful) / n
+        summary.avg_column_precision_at_5 = sum(r.column_precision_at_5 for r in successful) / n
+        summary.avg_column_precision_at_k = sum(r.column_precision_at_k for r in successful) / n
+        summary.avg_column_f1_at_1 = sum(r.column_f1_at_1 for r in successful) / n
+        summary.avg_column_f1_at_3 = sum(r.column_f1_at_3 for r in successful) / n
+        summary.avg_column_f1_at_5 = sum(r.column_f1_at_5 for r in successful) / n
+        summary.avg_column_f1_at_k = sum(r.column_f1_at_k for r in successful) / n
 
         # Advanced metrics
         summary.avg_table_mrr = sum(r.table_mrr for r in successful) / n
@@ -1539,6 +1747,28 @@ def generate_results_html(results: List[EvaluationResult],
             f"<td>{s.avg_column_precision:.4f}</td>"
             f"<td>{s.avg_column_recall:.4f}</td>"
             f"<td>{s.avg_column_f1:.4f}</td>"
+            f"<td>{s.avg_table_recall_at_3:.4f}</td>"
+            f"<td>{s.avg_table_recall_at_5:.4f}</td>"
+            f"<td>{s.avg_table_recall_at_k:.4f}</td>"
+            f"<td>{s.avg_column_recall_at_3:.4f}</td>"
+            f"<td>{s.avg_column_recall_at_5:.4f}</td>"
+            f"<td>{s.avg_column_recall_at_k:.4f}</td>"
+            f"<td>{s.avg_table_precision_at_1:.4f}</td>"
+            f"<td>{s.avg_table_precision_at_3:.4f}</td>"
+            f"<td>{s.avg_table_precision_at_5:.4f}</td>"
+            f"<td>{s.avg_table_precision_at_k:.4f}</td>"
+            f"<td>{s.avg_table_f1_at_1:.4f}</td>"
+            f"<td>{s.avg_table_f1_at_3:.4f}</td>"
+            f"<td>{s.avg_table_f1_at_5:.4f}</td>"
+            f"<td>{s.avg_table_f1_at_k:.4f}</td>"
+            f"<td>{s.avg_column_precision_at_1:.4f}</td>"
+            f"<td>{s.avg_column_precision_at_3:.4f}</td>"
+            f"<td>{s.avg_column_precision_at_5:.4f}</td>"
+            f"<td>{s.avg_column_precision_at_k:.4f}</td>"
+            f"<td>{s.avg_column_f1_at_1:.4f}</td>"
+            f"<td>{s.avg_column_f1_at_3:.4f}</td>"
+            f"<td>{s.avg_column_f1_at_5:.4f}</td>"
+            f"<td>{s.avg_column_f1_at_k:.4f}</td>"
             f"<td>{s.table_hit_at_1_rate:.2%}</td>"
             f"<td>{s.table_hit_at_3_rate:.2%}</td>"
             f"<td>{s.table_hit_at_5_rate:.2%}</td>"
@@ -1584,6 +1814,28 @@ def generate_results_html(results: List[EvaluationResult],
             f"<td>{r.column_precision:.4f}</td>"
             f"<td>{r.column_recall:.4f}</td>"
             f"<td>{r.column_f1:.4f}</td>"
+            f"<td>{r.table_recall_at_3:.4f}</td>"
+            f"<td>{r.table_recall_at_5:.4f}</td>"
+            f"<td>{r.table_recall_at_k:.4f}</td>"
+            f"<td>{r.column_recall_at_3:.4f}</td>"
+            f"<td>{r.column_recall_at_5:.4f}</td>"
+            f"<td>{r.column_recall_at_k:.4f}</td>"
+            f"<td>{r.table_precision_at_1:.4f}</td>"
+            f"<td>{r.table_precision_at_3:.4f}</td>"
+            f"<td>{r.table_precision_at_5:.4f}</td>"
+            f"<td>{r.table_precision_at_k:.4f}</td>"
+            f"<td>{r.table_f1_at_1:.4f}</td>"
+            f"<td>{r.table_f1_at_3:.4f}</td>"
+            f"<td>{r.table_f1_at_5:.4f}</td>"
+            f"<td>{r.table_f1_at_k:.4f}</td>"
+            f"<td>{r.column_precision_at_1:.4f}</td>"
+            f"<td>{r.column_precision_at_3:.4f}</td>"
+            f"<td>{r.column_precision_at_5:.4f}</td>"
+            f"<td>{r.column_precision_at_k:.4f}</td>"
+            f"<td>{r.column_f1_at_1:.4f}</td>"
+            f"<td>{r.column_f1_at_3:.4f}</td>"
+            f"<td>{r.column_f1_at_5:.4f}</td>"
+            f"<td>{r.column_f1_at_k:.4f}</td>"
             f"<td>{'Y' if r.table_hit_at_1 else 'N'}</td>"
             f"<td>{'Y' if r.table_hit_at_3 else 'N'}</td>"
             f"<td>{'Y' if r.table_hit_at_5 else 'N'}</td>"
@@ -1732,6 +1984,12 @@ def generate_results_html(results: List[EvaluationResult],
         <th>Avg Time (ms)</th>
         <th>Table P</th><th>Table R</th><th>Table F1</th>
         <th>Col P</th><th>Col R</th><th>Col F1</th>
+        <th>Tbl R@3</th><th>Tbl R@5</th><th>Tbl R@K</th>
+        <th>Col R@3</th><th>Col R@5</th><th>Col R@K</th>
+        <th>Tbl P@1</th><th>Tbl P@3</th><th>Tbl P@5</th><th>Tbl P@K</th>
+        <th>Tbl F1@1</th><th>Tbl F1@3</th><th>Tbl F1@5</th><th>Tbl F1@K</th>
+        <th>Col P@1</th><th>Col P@3</th><th>Col P@5</th><th>Col P@K</th>
+        <th>Col F1@1</th><th>Col F1@3</th><th>Col F1@5</th><th>Col F1@K</th>
         <th>Hit@1</th><th>Hit@3</th><th>Hit@5</th>
         <th>MRR</th><th>Jaccard</th><th>Exact Match</th><th>Joint Col F1</th>
         <th>Top-N Tbl</th><th>Top-N Col</th>
@@ -1760,6 +2018,12 @@ def generate_results_html(results: List[EvaluationResult],
         <th>Expected Tables</th><th>Discovered Tables</th>
         <th>Table P</th><th>Table R</th><th>Table F1</th>
         <th>Col P</th><th>Col R</th><th>Col F1</th>
+        <th>Tbl R@3</th><th>Tbl R@5</th><th>Tbl R@K</th>
+        <th>Col R@3</th><th>Col R@5</th><th>Col R@K</th>
+        <th>Tbl P@1</th><th>Tbl P@3</th><th>Tbl P@5</th><th>Tbl P@K</th>
+        <th>Tbl F1@1</th><th>Tbl F1@3</th><th>Tbl F1@5</th><th>Tbl F1@K</th>
+        <th>Col P@1</th><th>Col P@3</th><th>Col P@5</th><th>Col P@K</th>
+        <th>Col F1@1</th><th>Col F1@3</th><th>Col F1@5</th><th>Col F1@K</th>
         <th>Hit@1</th><th>Hit@3</th><th>Hit@5</th><th>MRR</th>
         <th>Top-N Tbl</th><th>Top-N Col</th>
         <th>Error</th>
@@ -2000,7 +2264,9 @@ def start_results_server(html_content: str, port: int = 8787):
 
 def process_database(oracle_mgr: OracleManager, db_id: str,
                     ddl_folder: str, questions: List[Dict],
-                    index_script: str) -> Tuple[List[EvaluationResult], DatabaseSummary, float]:
+                    index_script: str,
+                    use_parallel_discovery: bool = False,
+                    discover_cfg: Optional[DiscoveryConfig] = None) -> Tuple[List[EvaluationResult], DatabaseSummary, float]:
     """
     Process a single database: create user, run DDL, evaluate queries.
 
@@ -2061,7 +2327,13 @@ def process_database(oracle_mgr: OracleManager, db_id: str,
     print(f"  Index setup time: {index_setup_time_ms:.2f}ms")
 
     # Step 6: Process questions
-    results, summary = evaluate_questions_for_db(oracle_mgr, db_id, questions)
+    results, summary = evaluate_questions_for_db(
+        oracle_mgr,
+        db_id,
+        questions,
+        use_parallel_discovery=use_parallel_discovery,
+        discover_cfg=discover_cfg
+    )
 
     # Step 7: Drop user
     oracle_mgr.drop_user(db_id)
@@ -2070,11 +2342,15 @@ def process_database(oracle_mgr: OracleManager, db_id: str,
 
 
 def evaluate_questions_for_db(oracle_mgr: OracleManager, db_id: str,
-                              questions: List[Dict]) -> Tuple[List[EvaluationResult], DatabaseSummary]:
+                              questions: List[Dict],
+                              use_parallel_discovery: bool = False,
+                              discover_cfg: Optional[DiscoveryConfig] = None) -> Tuple[List[EvaluationResult], DatabaseSummary]:
     """Evaluate all questions for one db_id using the current connected user."""
     results = []
 
     print(f"\n  Processing {len(questions)} questions for {db_id}...")
+
+    cfg = discover_cfg or DiscoveryConfig()
 
     for i, question in enumerate(questions):
         question_id = question.get('question_id', i)
@@ -2111,9 +2387,15 @@ def evaluate_questions_for_db(oracle_mgr: OracleManager, db_id: str,
         try:
             discovered, exec_time = oracle_mgr.discover_objects(
                 query=question_text + " " + evidence,
-                k=10,
-                k0=50,
-                cols_per_obj=5
+                k=cfg.k,
+                k0=cfg.k0,
+                cols_per_obj=cfg.cols_per_obj,
+                use_parallel=use_parallel_discovery,
+                hints=evidence if use_parallel_discovery else None,
+                n=cfg.n,
+                m=cfg.m,
+                alpha=cfg.alpha,
+                parallel_alpha=cfg.parallel_alpha
             )
 
             result.execution_time_ms = exec_time
@@ -2127,7 +2409,7 @@ def evaluate_questions_for_db(oracle_mgr: OracleManager, db_id: str,
                 ])
 
                 # Evaluate results
-                metrics = evaluate_result(expected_objs, discovered)
+                metrics = evaluate_result(expected_objs, discovered, eval_k=cfg.k)
 
                 # Basic results
                 result.discovered_tables = metrics['discovered_tables']
@@ -2150,6 +2432,28 @@ def evaluate_questions_for_db(oracle_mgr: OracleManager, db_id: str,
                 result.table_recall_at_3 = metrics['recall_at_3']
                 result.table_recall_at_5 = metrics['recall_at_5']
                 result.table_recall_at_10 = metrics['recall_at_10']
+                result.table_recall_at_k = metrics['recall_at_k']
+
+                result.table_precision_at_1 = metrics['table_precision_at_1']
+                result.table_precision_at_3 = metrics['table_precision_at_3']
+                result.table_precision_at_5 = metrics['table_precision_at_5']
+                result.table_precision_at_k = metrics['table_precision_at_k']
+                result.table_f1_at_1 = metrics['table_f1_at_1']
+                result.table_f1_at_3 = metrics['table_f1_at_3']
+                result.table_f1_at_5 = metrics['table_f1_at_5']
+                result.table_f1_at_k = metrics['table_f1_at_k']
+
+                result.column_recall_at_3 = metrics['column_recall_at_3']
+                result.column_recall_at_5 = metrics['column_recall_at_5']
+                result.column_recall_at_k = metrics['column_recall_at_k']
+                result.column_precision_at_1 = metrics['column_precision_at_1']
+                result.column_precision_at_3 = metrics['column_precision_at_3']
+                result.column_precision_at_5 = metrics['column_precision_at_5']
+                result.column_precision_at_k = metrics['column_precision_at_k']
+                result.column_f1_at_1 = metrics['column_f1_at_1']
+                result.column_f1_at_3 = metrics['column_f1_at_3']
+                result.column_f1_at_5 = metrics['column_f1_at_5']
+                result.column_f1_at_k = metrics['column_f1_at_k']
 
                 # Advanced metrics
                 result.table_mrr = metrics['mrr']
@@ -2197,6 +2501,8 @@ def process_databases_single_user(
     index_script: str,
     max_questions: Optional[int],
     username: str,
+    use_parallel_discovery: bool,
+    discover_cfg: Optional[DiscoveryConfig],
 ) -> Tuple[List[EvaluationResult], List[DatabaseSummary], float]:
     """Load all schemas into one user and evaluate all queries in that shared schema."""
     all_results: List[EvaluationResult] = []
@@ -2261,12 +2567,46 @@ def process_databases_single_user(
         if max_questions is not None:
             questions = questions[:max_questions]
 
-        results, summary = evaluate_questions_for_db(oracle_mgr, db_id, questions)
+        results, summary = evaluate_questions_for_db(
+            oracle_mgr,
+            db_id,
+            questions,
+            use_parallel_discovery=use_parallel_discovery,
+            discover_cfg=discover_cfg
+        )
         all_results.extend(results)
         all_summaries.append(summary)
 
     oracle_mgr.drop_user(username)
     return all_results, all_summaries, index_setup_time_ms
+
+
+def build_discovery_config(args: argparse.Namespace) -> DiscoveryConfig:
+    """Build discovery config from defaults + optional JSON blob + explicit CLI overrides."""
+    cfg = DiscoveryConfig()
+
+    if args.discover_config_json:
+        raw = json.loads(args.discover_config_json)
+        for key in ['k', 'k0', 'n', 'm', 'cols_per_obj', 'alpha', 'parallel_alpha']:
+            if key in raw:
+                setattr(cfg, key, raw[key])
+
+    if args.discover_k is not None:
+        cfg.k = args.discover_k
+    if args.discover_k0 is not None:
+        cfg.k0 = args.discover_k0
+    if args.discover_n is not None:
+        cfg.n = args.discover_n
+    if args.discover_m is not None:
+        cfg.m = args.discover_m
+    if args.discover_cols_per_obj is not None:
+        cfg.cols_per_obj = args.discover_cols_per_obj
+    if args.discover_alpha is not None:
+        cfg.alpha = args.discover_alpha
+    if args.discover_parallel_alpha is not None:
+        cfg.parallel_alpha = args.discover_parallel_alpha
+
+    return cfg
 
 
 def main():
@@ -2359,6 +2699,25 @@ def main():
         default='BIRD_ALL',
         help='Username to use with --single-user-mode (default: BIRD_ALL)'
     )
+    parser.add_argument(
+        '--parallel-discovery',
+        action='store_true',
+        help='Use developer.discover_objects_parallel() instead of discover_objects()'
+    )
+
+    discover_group = parser.add_argument_group('Discovery settings')
+    discover_group.add_argument(
+        '--discover-config-json',
+        default=None,
+        help='JSON blob for discovery args, e.g. {"k":10,"k0":50,"cols_per_obj":5,"alpha":0.65,"parallel_alpha":0.6}'
+    )
+    discover_group.add_argument('--discover-k', type=int, default=None, help='Top K output objects (overrides config JSON)')
+    discover_group.add_argument('--discover-k0', type=int, default=None, help='Sequential stage-1 object topN')
+    discover_group.add_argument('--discover-n', type=int, default=None, help='Sequential stage-2 column topN (p_n)')
+    discover_group.add_argument('--discover-m', type=int, default=None, help='Parallel column topN (p_m)')
+    discover_group.add_argument('--discover-cols-per-obj', type=int, default=None, help='Columns attached per object')
+    discover_group.add_argument('--discover-alpha', type=float, default=None, help='Sequential score blend alpha')
+    discover_group.add_argument('--discover-parallel-alpha', type=float, default=None, help='Parallel score blend alpha')
 
     args = parser.parse_args()
 
@@ -2418,6 +2777,11 @@ def main():
 
     output_source = args.output_source
     html_content = ""
+    try:
+        discover_cfg = build_discovery_config(args)
+    except json.JSONDecodeError as e:
+        print(f"Error: invalid --discover-config-json: {e}")
+        return 1
 
     try:
         all_results = []
@@ -2432,6 +2796,8 @@ def main():
                 index_script=args.index_script,
                 max_questions=args.max_questions,
                 username=args.single_user_name,
+                use_parallel_discovery=args.parallel_discovery,
+                discover_cfg=discover_cfg,
             )
         else:
             for db_id in sorted(ddl_folders):
@@ -2447,7 +2813,9 @@ def main():
                     questions = questions[:args.max_questions]
 
                 results, summary, index_setup_time_ms = process_database(
-                    oracle_mgr, db_id, ddl_folder, questions, args.index_script
+                    oracle_mgr, db_id, ddl_folder, questions, args.index_script,
+                    use_parallel_discovery=args.parallel_discovery,
+                    discover_cfg=discover_cfg
                 )
 
                 all_results.extend(results)
@@ -2471,12 +2839,17 @@ def main():
             'max_questions': args.max_questions or 'all',
             'max_databases': args.max_databases or 'all',
             'output_source': output_source,
-            'discover_k': 10,
-            'discover_k0': 50,
-            'discover_cols_per_obj': 5,
+            'discover_k': discover_cfg.k,
+            'discover_k0': discover_cfg.k0,
+            'discover_n': discover_cfg.n,
+            'discover_m': discover_cfg.m,
+            'discover_cols_per_obj': discover_cfg.cols_per_obj,
+            'discover_alpha': discover_cfg.alpha,
+            'discover_parallel_alpha': discover_cfg.parallel_alpha,
             'index_setup_time_ms': f'{total_index_setup_time_ms:.2f}',
             'single_user_mode': args.single_user_mode,
             'single_user_name': args.single_user_name if args.single_user_mode else 'n/a',
+            'parallel_discovery': args.parallel_discovery,
             'timestamp': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
         }
 


### PR DESCRIPTION
### Motivation
- Provide a single, reproducible place to set discovery procedure arguments (k, k0, n, m, cols_per_obj, alpha, parallel_alpha) instead of scattered hardcoded values. 
- Allow experiments to invoke the new parallel PL/SQL discovery path and tune its parameters easily. 
- Expose richer ranking metrics (@1/@3/@5/@K precision, recall, and F1) for both table and column evaluation so results are more informative for multi-table queries.

### Description
- Added a `DiscoveryConfig` dataclass and a `--discover-config-json` CLI subgroup with explicit overrides (`--discover-k`, `--discover-k0`, `--discover-n`, `--discover-m`, `--discover-cols-per-obj`, `--discover-alpha`, `--discover-parallel-alpha`) and threaded this config through `process_databases_single_user`, `process_database`, and `evaluate_questions_for_db` so discovery args are applied per-run.
- Extended `OracleManager.discover_objects()` signature to accept `n`, `m`, `alpha`, and `parallel_alpha` and to call either `developer.discover_objects` or `developer.discover_objects_parallel` depending on `use_parallel`, passing the configured PL/SQL parameters.
- Implemented a new PL/SQL procedure `discover_objects_parallel` in `index_creation.sql` that performs parallel hybrid object+column search and returns a JSON result shape including `columns`/`dataType` and per-column scores.
- Added ranking metric helpers (`calculate_precision_recall_f1_at_k`) and extended `evaluate_result` to compute Precision@1/3/5/K, Recall@3/5/K, and F1@1/3/5/K for both tables and columns; these metrics are stored on `EvaluationResult` and averaged in `DatabaseSummary` and emitted in CSV and the HTML report (both summary and per-query tables).

### Testing
- Compiled the modified module with `python -m py_compile run_hybrid_search_evaluation.py` which completed without syntax errors. 
- Performed a basic repository sanity check (`git diff --check`) which reported no trailing whitespace or similar issues. 
- Verified the main reporting paths were updated: CSV writers and HTML generation include the new metric columns and run parameters (manual inspection / static verification of generated templates).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d5b157690832287e6778ba3944352)