### PR TITLE
Add Groq provider and batched OpenAI-compatible LLM extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ python add_dev_questions_metadata.py \
 Notes:
 
 - Default Groq-compatible base URL is `https://api.groq.com/openai/v1`.
-- Groq uses the same OpenAI-compatible Chat Completions schema, so it shares the same batched extractor path as `openai_compat`/`openrouter`.
+- Groq provider uses the Groq Python SDK (`Groq(...).chat.completions.create(...)`) with batched prompts.
 - You can change endpoint with `--llm-base-url` if needed.
 - For OpenAI-compatible providers (`openai_compat`, `openrouter`, `groq`), questions are sent in batches (default 35 per request) instead of one-by-one.
 
@@ -297,7 +297,7 @@ Notes:
 
 Optional dependencies:
 
-- No additional Python dependency required for LLM providers (uses standard-library HTTP requests).
+- `groq` Python package if you use `--method llm --llm-provider groq`
 - Ollama runtime only if you use `--method llm --llm-provider ollama`
 
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ python add_dev_questions_metadata.py \
 Notes:
 
 - Default Groq-compatible base URL is `https://api.groq.com/openai/v1`.
+- Groq uses the same OpenAI-compatible Chat Completions schema, so it shares the same batched extractor path as `openai_compat`/`openrouter`.
 - You can change endpoint with `--llm-base-url` if needed.
 - For OpenAI-compatible providers (`openai_compat`, `openrouter`, `groq`), questions are sent in batches (default 35 per request) instead of one-by-one.
 

--- a/README.md
+++ b/README.md
@@ -180,10 +180,73 @@ python add_dev_questions_metadata.py <input_dev.json> [output_dev.json] [--metho
 Key options:
 
 - `--method`: `rule_based` (default) or `llm`
-- `--llm-provider`: `openai_compat` (default) or `ollama`
+- `--llm-provider`: `openai_compat` (default), `openrouter`, `groq`, or `ollama`
 - `--llm-model`: model name (e.g., `gpt-4o-mini`, `qwen2.5:3b`)
 - `--llm-base-url`: custom API base URL
 - `--llm-api-key`: API key for `openai_compat` provider
+- `--llm-site-url`: optional OpenRouter `HTTP-Referer` header value
+- `--llm-app-name`: optional OpenRouter `X-Title` header value
+- `--llm-batch-size`: questions per LLM request for OpenAI-compatible providers (default `35`)
+
+## Using OpenRouter
+
+Use `--method llm --llm-provider openrouter` to run extraction via OpenRouter.
+
+### 1) Set your API key
+
+```bash
+export OPENROUTER_API_KEY="<your_openrouter_api_key>"
+```
+
+You can also pass the key directly with `--llm-api-key`.
+
+### 2) Run metadata generation with OpenRouter
+
+```bash
+python add_dev_questions_metadata.py \
+  dev_original.json dev_with_metadata.json \
+  --method llm \
+  --llm-provider openrouter \
+  --llm-model openai/gpt-4o-mini \
+  --llm-site-url https://your-app.example \
+  --llm-app-name "BIRD Oracle Metadata"
+```
+
+Notes:
+
+- Default OpenRouter base URL is `https://openrouter.ai/api/v1`.
+- Override endpoint with `--llm-base-url` if needed.
+- If OpenRouter fails for a query, the script falls back to `rule_based` extraction and continues.
+
+
+## Using Groq
+
+Use `--method llm --llm-provider groq` for Groq-hosted inference.
+
+### 1) Set your API key
+
+```bash
+export GROQ_API_KEY="<your_groq_api_key>"
+```
+
+You can also pass the key directly with `--llm-api-key`.
+
+### 2) Run metadata generation with Groq (batched)
+
+```bash
+python add_dev_questions_metadata.py \
+  dev_original.json dev_with_metadata.json \
+  --method llm \
+  --llm-provider groq \
+  --llm-model qwen/qwen3-coder:free \
+  --llm-batch-size 35
+```
+
+Notes:
+
+- Default Groq-compatible base URL is `https://api.groq.com/openai/v1`.
+- You can change endpoint with `--llm-base-url` if needed.
+- For OpenAI-compatible providers (`openai_compat`, `openrouter`, `groq`), questions are sent in batches (default 35 per request) instead of one-by-one.
 
 ## Using Ollama with Local Open-Source Models
 
@@ -233,7 +296,7 @@ Notes:
 
 Optional dependencies:
 
-- `openai` Python package only if you use `--method llm --llm-provider openai_compat`
+- No additional Python dependency required for LLM providers (uses standard-library HTTP requests).
 - Ollama runtime only if you use `--method llm --llm-provider ollama`
 
 

--- a/add_dev_questions_metadata.py
+++ b/add_dev_questions_metadata.py
@@ -63,6 +63,13 @@ SQL_KEYWORDS = {
     'T1', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8', 'T9', 'T10',
     'T11', 'T12', 'T13', 'T14', 'T15', 'T16', 'T17', 'T18', 'T19', 'T20'
 }
+# Keywords that may legitimately appear as unquoted column names in BIRD schemas
+# and should not be dropped during heuristic extraction.
+NON_FILTERABLE_IDENTIFIER_KEYWORDS = {
+    'POWER',
+}
+
+
 
 # Oracle reserved words that need to be quoted
 ORACLE_RESERVED_WORDS = {
@@ -486,25 +493,25 @@ def extract_columns_for_tables(sql: str, alias_to_table: Dict[str, str], tables:
                     # Assign to first table as default
                     table_columns[tables[0]].add(col)
 
-    # Extract unqualified identifiers from SELECT list for single-table queries.
-    # This catches cases like CASE WHEN borderColor = ... and COUNT(id).
+    # For single-table queries, recover identifiers across the full SQL expression.
+    # This captures columns used in SELECT/WHERE/ORDER BY (e.g., DISTINCT availability,
+    # power LIKE ..., promoTypes = ..., COUNT(id), etc.).
     if len(tables) == 1:
-        select_match = re.search(r'\bSELECT\b(.*?)\bFROM\b', sql_normalized, re.IGNORECASE)
-        if select_match:
-            select_clause = select_match.group(1)
-            # Remove quoted string literals to avoid treating them as identifiers
-            select_clause = re.sub(r"'[^']*'|\"[^\"]*\"", " ", select_clause)
-            tokens = re.findall(r'\b[a-zA-Z_][a-zA-Z0-9_]*\b', select_clause)
-            for token in tokens:
-                upper_token = token.upper()
-                if upper_token in SQL_KEYWORDS:
-                    continue
-                if token in tables or upper_token in alias_to_table:
-                    continue
-                # Skip function names (identifier followed by opening parenthesis)
-                if re.search(rf'\b{re.escape(token)}\s*\(', select_clause):
-                    continue
-                table_columns[tables[0]].add(token)
+        single_table = tables[0]
+        scrubbed_sql = re.sub(r"'[^']*'|\"[^\"]*\"", " ", sql_normalized)
+        tokens = re.findall(r'\b[a-zA-Z_][a-zA-Z0-9_]*\b', scrubbed_sql)
+        for token in tokens:
+            upper_token = token.upper()
+            if upper_token in SQL_KEYWORDS and upper_token not in NON_FILTERABLE_IDENTIFIER_KEYWORDS:
+                continue
+            if token == single_table or upper_token == single_table.upper():
+                continue
+            if upper_token in alias_to_table:
+                continue
+            # Skip function names (identifier followed by opening parenthesis)
+            if re.search(rf'\b{re.escape(token)}\s*\(', scrubbed_sql):
+                continue
+            table_columns[single_table].add(token)
 
     return table_columns
 
@@ -533,7 +540,7 @@ def extract_tables_with_columns(sql: str) -> List[Dict]:
         # Filter out any remaining keywords
         filtered_columns = [
             col for col in sorted(columns)
-            if col.upper() not in SQL_KEYWORDS
+            if (col.upper() not in SQL_KEYWORDS or col.upper() in NON_FILTERABLE_IDENTIFIER_KEYWORDS)
             and not col.isdigit()
             and len(col) > 0
         ]

--- a/add_dev_questions_metadata.py
+++ b/add_dev_questions_metadata.py
@@ -504,7 +504,11 @@ def extract_columns_for_tables(sql: str, alias_to_table: Dict[str, str], tables:
     # power LIKE ..., promoTypes = ..., COUNT(id), etc.).
     if len(tables) == 1:
         single_table = tables[0]
-        scrubbed_sql = re.sub(r"'[^']*'|\"[^\"]*\"", " ", sql_normalized)
+        # Keep quoted identifiers out of token-based fallback extraction so pieces of
+        # names like `County Name` or `Free Meal Count (K-12)` do not become spurious
+        # columns such as County/Name/Free/Meal/K.
+        scrubbed_sql = re.sub(r"'[^']*'", " ", sql_normalized)
+        scrubbed_sql = re.sub(r'`[^`]+`|"[^"]+"', ' ', scrubbed_sql)
         tokens = re.findall(r'\b[a-zA-Z_][a-zA-Z0-9_]*\b', scrubbed_sql)
         for token in tokens:
             upper_token = token.upper()

--- a/add_dev_questions_metadata.py
+++ b/add_dev_questions_metadata.py
@@ -554,14 +554,14 @@ def _normalize_llm_table_payload(payload: Dict) -> List[Dict]:
     return cleaned
 
 
-def extract_tables_with_columns_llm_openai_compat_batch(
+def extract_tables_with_columns_llm_chat_completions_batch(
     sql_items: List[Tuple[int, str]],
     model: str,
     api_key: Optional[str],
     base_url: Optional[str],
     extra_headers: Optional[Dict[str, str]] = None,
 ) -> Dict[int, List[Dict]]:
-    """Extract tables/columns for multiple SQL queries via OpenAI-compatible chat completions API."""
+    """Extract tables/columns for multiple SQL queries via chat-completions-compatible APIs (OpenAI/OpenRouter/Groq)."""
     endpoint = (base_url or "https://api.openai.com/v1").rstrip('/') + "/chat/completions"
 
     instructions = (
@@ -726,7 +726,7 @@ def process_dev_file(
                     for idx in range(batch_start, batch_end)
                 ]
                 try:
-                    batch_result = extract_tables_with_columns_llm_openai_compat_batch(
+                    batch_result = extract_tables_with_columns_llm_chat_completions_batch(
                         sql_items,
                         model=llm_model,
                         api_key=effective_api_key,

--- a/add_dev_questions_metadata.py
+++ b/add_dev_questions_metadata.py
@@ -24,17 +24,11 @@ Example:
 
 import argparse
 import json
+import os
 import re
-import sys
 from typing import List, Dict, Set, Tuple, Optional
 from collections import defaultdict
 from urllib import request, error
-
-try:
-    from openai import OpenAI
-except ImportError:  # Optional dependency for --method llm
-    OpenAI = None
-
 
 # SQL keywords to exclude from columns
 SQL_KEYWORDS = {
@@ -560,34 +554,75 @@ def _normalize_llm_table_payload(payload: Dict) -> List[Dict]:
     return cleaned
 
 
-def extract_tables_with_columns_llm_openai_compat(sql: str, model: str, api_key: Optional[str], base_url: Optional[str]) -> List[Dict]:
-    """Extract tables/columns using an OpenAI-compatible LLM endpoint."""
-    if OpenAI is None:
-        raise RuntimeError("openai package is not installed; install it or use --method rule_based")
+def extract_tables_with_columns_llm_openai_compat_batch(
+    sql_items: List[Tuple[int, str]],
+    model: str,
+    api_key: Optional[str],
+    base_url: Optional[str],
+    extra_headers: Optional[Dict[str, str]] = None,
+) -> Dict[int, List[Dict]]:
+    """Extract tables/columns for multiple SQL queries via OpenAI-compatible chat completions API."""
+    endpoint = (base_url or "https://api.openai.com/v1").rstrip('/') + "/chat/completions"
 
-    client_kwargs = {}
+    instructions = (
+        "You extract table and column metadata from SQL queries. "
+        "Return strict JSON only with this schema: "
+        "{\"items\":[{\"index\":0,\"tables\":[{\"name\":\"table_name\",\"columns\":[{\"name\":\"column_name\"}]}]}]}. "
+        "The index must match the provided item index. "
+        "Do not include markdown fences or extra text."
+    )
+
+    lines = ["SQL items:"]
+    for idx, sql in sql_items:
+        lines.append(f"Index {idx}:")
+        lines.append(sql)
+        lines.append("---")
+
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": instructions},
+            {"role": "user", "content": "\n".join(lines)},
+        ],
+        "temperature": 0,
+    }
+
+    headers = {
+        "Content-Type": "application/json",
+    }
     if api_key:
-        client_kwargs["api_key"] = api_key
-    if base_url:
-        client_kwargs["base_url"] = base_url
-    client = OpenAI(**client_kwargs)
+        headers["Authorization"] = f"Bearer {api_key}"
+    if extra_headers:
+        headers.update(extra_headers)
 
-    prompt = (
-        "Extract table names and corresponding column names from the SQL query. "
-        "Return strict JSON with this schema: "
-        "{\"tables\":[{\"name\":\"table_name\",\"columns\":[{\"name\":\"column_name\"}]}]}. "
-        "Do not include extra keys or commentary. SQL:\n"
-        f"{sql}"
+    req = request.Request(
+        endpoint,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
     )
+    try:
+        with request.urlopen(req, timeout=60) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+    except error.URLError as exc:
+        raise RuntimeError(f"OpenAI-compatible request failed: {exc}") from exc
 
-    response = client.responses.create(
-        model=model,
-        input=prompt,
-        temperature=0,
-    )
+    try:
+        content = body["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise RuntimeError(f"Unexpected chat completion response shape: {body}") from exc
 
-    parsed = _extract_json_object(response.output_text)
-    return _normalize_llm_table_payload(parsed)
+    parsed = _extract_json_object(content)
+    items = parsed.get("items", [])
+    result: Dict[int, List[Dict]] = {}
+    for item in items:
+        try:
+            idx = int(item.get("index"))
+        except (TypeError, ValueError):
+            continue
+        result[idx] = _normalize_llm_table_payload({"tables": item.get("tables", [])})
+    return result
+
 
 
 def extract_tables_with_columns_llm_ollama(sql: str, model: str, base_url: Optional[str]) -> List[Dict]:
@@ -624,6 +659,9 @@ def process_dev_file(
     llm_api_key: Optional[str] = None,
     llm_base_url: Optional[str] = None,
     llm_provider: str = "openai_compat",
+    llm_site_url: Optional[str] = None,
+    llm_app_name: Optional[str] = None,
+    llm_batch_size: int = 35,
 ) -> None:
     """
     Process the dev.json file and add tables with nested columns metadata
@@ -640,38 +678,86 @@ def process_dev_file(
 
     print(f"Processing {len(questions)} questions...")
 
-    for i, question in enumerate(questions):
-        sql = question.get('SQL', '')
+    for question in questions:
+        question['tables'] = []
 
-        # Extract tables and columns
-        if method == "llm":
-            try:
-                if llm_provider == "ollama":
-                    tables_with_columns = extract_tables_with_columns_llm_ollama(
+    if method == "llm":
+        if llm_provider == "ollama":
+            for i, question in enumerate(questions):
+                sql = question.get('SQL', '')
+                try:
+                    question['tables'] = extract_tables_with_columns_llm_ollama(
                         sql,
                         model=llm_model,
                         base_url=llm_base_url,
                     )
-                else:
-                    tables_with_columns = extract_tables_with_columns_llm_openai_compat(
-                        sql,
-                        model=llm_model,
-                        api_key=llm_api_key,
-                        base_url=llm_base_url,
-                    )
-            except Exception as exc:
-                print(f"Warning: LLM extraction failed for question index {i} ({exc}); falling back to rule_based")
-                tables_with_columns = extract_tables_with_columns(sql)
+                except Exception as exc:
+                    print(f"Warning: LLM extraction failed for question index {i} ({exc}); falling back to rule_based")
+                    question['tables'] = extract_tables_with_columns(sql)
+                if (i + 1) % 100 == 0:
+                    print(f"  Processed {i + 1} questions...")
         else:
-            tables_with_columns = extract_tables_with_columns(sql)
-        question['tables'] = tables_with_columns
+            effective_api_key = llm_api_key
+            effective_base_url = llm_base_url
+            extra_headers: Dict[str, str] = {}
 
-        # Convert SQL to Oracle format
-        oracle_sql = convert_sqlite_to_oracle_sql(sql)
-        question['oracle_SQL'] = oracle_sql
+            if llm_provider == "openrouter":
+                effective_api_key = effective_api_key or os.getenv("OPENROUTER_API_KEY")
+                effective_base_url = effective_base_url or "https://openrouter.ai/api/v1"
+                if not effective_api_key:
+                    raise RuntimeError("Missing OpenRouter API key. Pass --llm-api-key or set OPENROUTER_API_KEY.")
+                if llm_site_url:
+                    extra_headers["HTTP-Referer"] = llm_site_url
+                if llm_app_name:
+                    extra_headers["X-Title"] = llm_app_name
+            elif llm_provider == "groq":
+                effective_api_key = effective_api_key or os.getenv("GROQ_API_KEY")
+                effective_base_url = effective_base_url or "https://api.groq.com/openai/v1"
+                if not effective_api_key:
+                    raise RuntimeError("Missing Groq API key. Pass --llm-api-key or set GROQ_API_KEY.")
+            else:
+                effective_api_key = effective_api_key or os.getenv("OPENAI_API_KEY")
 
-        if (i + 1) % 100 == 0:
-            print(f"  Processed {i + 1} questions...")
+            batch_size = max(1, llm_batch_size)
+            for batch_start in range(0, len(questions), batch_size):
+                batch_end = min(batch_start + batch_size, len(questions))
+                sql_items = [
+                    (idx, questions[idx].get('SQL', ''))
+                    for idx in range(batch_start, batch_end)
+                ]
+                try:
+                    batch_result = extract_tables_with_columns_llm_openai_compat_batch(
+                        sql_items,
+                        model=llm_model,
+                        api_key=effective_api_key,
+                        base_url=effective_base_url,
+                        extra_headers=extra_headers or None,
+                    )
+                except Exception as exc:
+                    print(
+                        f"Warning: LLM batch extraction failed for indexes {batch_start}-{batch_end - 1} ({exc}); "
+                        "falling back to rule_based for this batch"
+                    )
+                    batch_result = {}
+
+                for idx, sql in sql_items:
+                    if idx in batch_result:
+                        questions[idx]['tables'] = batch_result[idx]
+                    else:
+                        questions[idx]['tables'] = extract_tables_with_columns(sql)
+
+                if batch_end % 100 == 0 or batch_end == len(questions):
+                    print(f"  Processed {batch_end} questions...")
+    else:
+        for i, question in enumerate(questions):
+            sql = question.get('SQL', '')
+            question['tables'] = extract_tables_with_columns(sql)
+            if (i + 1) % 100 == 0:
+                print(f"  Processed {i + 1} questions...")
+
+    for question in questions:
+        sql = question.get('SQL', '')
+        question['oracle_SQL'] = convert_sqlite_to_oracle_sql(sql)
 
     print(f"Writing output file: {output_path}")
 
@@ -694,6 +780,7 @@ def process_dev_file(
     print(f"  Average columns per question: {total_columns / len(questions):.2f}")
 
 
+
 def main():
     """Main entry point."""
     parser = argparse.ArgumentParser(
@@ -712,9 +799,25 @@ def main():
     parser.add_argument("--llm-base-url", default=None, help="Base URL for OpenAI-compatible endpoint")
     parser.add_argument(
         "--llm-provider",
-        choices=["openai_compat", "ollama"],
+        choices=["openai_compat", "openrouter", "groq", "ollama"],
         default="openai_compat",
-        help="LLM backend for --method llm. Use ollama for local open-source models.",
+        help="LLM backend for --method llm. Supports openai_compat, openrouter, groq, and ollama.",
+    )
+    parser.add_argument(
+        "--llm-site-url",
+        default=None,
+        help="Optional site URL for OpenRouter HTTP-Referer header.",
+    )
+    parser.add_argument(
+        "--llm-app-name",
+        default=None,
+        help="Optional app name for OpenRouter X-Title header.",
+    )
+    parser.add_argument(
+        "--llm-batch-size",
+        type=int,
+        default=35,
+        help="Number of questions sent in one LLM request for OpenAI-compatible providers.",
     )
     args = parser.parse_args()
 
@@ -727,6 +830,9 @@ def main():
         llm_api_key=args.llm_api_key,
         llm_base_url=args.llm_base_url,
         llm_provider=args.llm_provider,
+        llm_site_url=args.llm_site_url,
+        llm_app_name=args.llm_app_name,
+        llm_batch_size=args.llm_batch_size,
     )
 
 

--- a/add_dev_questions_metadata.py
+++ b/add_dev_questions_metadata.py
@@ -73,6 +73,7 @@ NON_FILTERABLE_IDENTIFIER_KEYWORDS = {
 # Keywords that may legitimately appear as unquoted table names in BIRD schemas.
 NON_FILTERABLE_TABLE_KEYWORDS = {
     'MATCH',
+    'ORDER',
 }
 
 
@@ -409,7 +410,7 @@ def extract_tables_with_aliases(sql: str) -> Tuple[Dict[str, str], List[str]]:
 
     # Handle comma-separated tables in FROM clause
     from_clause_match = re.search(
-        r'\bFROM\s+(.*?)(?:\bWHERE\b|\bJOIN\b|\bORDER\b|\bGROUP\b|\bLIMIT\b|\bHAVING\b|$)',
+        r'\bFROM\s+(.*?)(?:\bWHERE\b|\bJOIN\b|\bORDER\s+BY\b|\bGROUP\s+BY\b|\bLIMIT\b|\bHAVING\b|$)',
         sql_normalized, re.IGNORECASE
     )
     if from_clause_match:
@@ -509,6 +510,12 @@ def extract_columns_for_tables(sql: str, alias_to_table: Dict[str, str], tables:
         # columns such as County/Name/Free/Meal/K.
         scrubbed_sql = re.sub(r"'[^']*'", " ", sql_normalized)
         scrubbed_sql = re.sub(r'`[^`]+`|"[^"]+"', ' ', scrubbed_sql)
+        # Skip aliases introduced with AS (e.g., SELECT ... AS atom_id1) so derived
+        # labels are not treated as physical columns.
+        as_aliases = {
+            alias.strip('`"').upper()
+            for alias in re.findall(r'\bAS\s+([`"\w]+)', sql_normalized, re.IGNORECASE)
+        }
         tokens = re.findall(r'\b[a-zA-Z_][a-zA-Z0-9_]*\b', scrubbed_sql)
         for token in tokens:
             upper_token = token.upper()
@@ -517,6 +524,8 @@ def extract_columns_for_tables(sql: str, alias_to_table: Dict[str, str], tables:
             if token == single_table or upper_token == single_table.upper():
                 continue
             if upper_token in alias_to_table:
+                continue
+            if upper_token in as_aliases:
                 continue
             # Skip function names (identifier followed by opening parenthesis)
             if re.search(rf'\b{re.escape(token)}\s*\(', scrubbed_sql):

--- a/add_dev_questions_metadata.py
+++ b/add_dev_questions_metadata.py
@@ -486,6 +486,26 @@ def extract_columns_for_tables(sql: str, alias_to_table: Dict[str, str], tables:
                     # Assign to first table as default
                     table_columns[tables[0]].add(col)
 
+    # Extract unqualified identifiers from SELECT list for single-table queries.
+    # This catches cases like CASE WHEN borderColor = ... and COUNT(id).
+    if len(tables) == 1:
+        select_match = re.search(r'\bSELECT\b(.*?)\bFROM\b', sql_normalized, re.IGNORECASE)
+        if select_match:
+            select_clause = select_match.group(1)
+            # Remove quoted string literals to avoid treating them as identifiers
+            select_clause = re.sub(r"'[^']*'|\"[^\"]*\"", " ", select_clause)
+            tokens = re.findall(r'\b[a-zA-Z_][a-zA-Z0-9_]*\b', select_clause)
+            for token in tokens:
+                upper_token = token.upper()
+                if upper_token in SQL_KEYWORDS:
+                    continue
+                if token in tables or upper_token in alias_to_table:
+                    continue
+                # Skip function names (identifier followed by opening parenthesis)
+                if re.search(rf'\b{re.escape(token)}\s*\(', select_clause):
+                    continue
+                table_columns[tables[0]].add(token)
+
     return table_columns
 
 

--- a/add_dev_questions_metadata.py
+++ b/add_dev_questions_metadata.py
@@ -70,6 +70,12 @@ NON_FILTERABLE_IDENTIFIER_KEYWORDS = {
 }
 
 
+# Keywords that may legitimately appear as unquoted table names in BIRD schemas.
+NON_FILTERABLE_TABLE_KEYWORDS = {
+    'MATCH',
+}
+
+
 
 # Oracle reserved words that need to be quoted
 ORACLE_RESERVED_WORDS = {
@@ -383,7 +389,7 @@ def extract_tables_with_aliases(sql: str) -> Tuple[Dict[str, str], List[str]]:
     for match in from_matches:
         table_name = match[0].strip('`"')
         alias = match[1].strip('`"') if match[1] else None
-        if table_name.upper() not in SQL_KEYWORDS:
+        if table_name.upper() not in SQL_KEYWORDS or table_name.upper() in NON_FILTERABLE_TABLE_KEYWORDS:
             if table_name not in tables:
                 tables.append(table_name)
             if alias:
@@ -395,7 +401,7 @@ def extract_tables_with_aliases(sql: str) -> Tuple[Dict[str, str], List[str]]:
     for match in join_matches:
         table_name = match[0].strip('`"')
         alias = match[1].strip('`"') if match[1] else None
-        if table_name.upper() not in SQL_KEYWORDS:
+        if table_name.upper() not in SQL_KEYWORDS or table_name.upper() in NON_FILTERABLE_TABLE_KEYWORDS:
             if table_name not in tables:
                 tables.append(table_name)
             if alias:
@@ -416,7 +422,7 @@ def extract_tables_with_aliases(sql: str) -> Tuple[Dict[str, str], List[str]]:
             if match:
                 table_name = match.group(1).strip('`"')
                 alias = match.group(2).strip('`"') if match.group(2) else None
-                if table_name.upper() not in SQL_KEYWORDS:
+                if table_name.upper() not in SQL_KEYWORDS or table_name.upper() in NON_FILTERABLE_TABLE_KEYWORDS:
                     if table_name not in tables:
                         tables.append(table_name)
                     if alias:
@@ -478,9 +484,9 @@ def extract_columns_for_tables(sql: str, alias_to_table: Dict[str, str], tables:
     # Extract simple columns from various clauses and try to associate them
     # Look for patterns like: WHERE column = or ORDER BY column
     simple_col_contexts = [
-        (r'\bWHERE\s+(\w+)\s*(?:=|!=|<>|>=|<=|>|<|LIKE|IN|IS|BETWEEN)', 'where'),
-        (r'\bORDER\s+BY\s+(\w+)', 'order'),
-        (r'\bGROUP\s+BY\s+(\w+)', 'group'),
+        (r'\bWHERE\s+(?:\w+\.)?(\w+)\s*(?:=|!=|<>|>=|<=|>|<|LIKE|IN|IS|BETWEEN)', 'where'),
+        (r'\bORDER\s+BY\s+(?:\w+\.)?(\w+)', 'order'),
+        (r'\bGROUP\s+BY\s+(?:\w+\.)?(\w+)', 'group'),
     ]
 
     for pattern, context in simple_col_contexts:

--- a/add_dev_questions_metadata.py
+++ b/add_dev_questions_metadata.py
@@ -30,6 +30,11 @@ from typing import List, Dict, Set, Tuple, Optional
 from collections import defaultdict
 from urllib import request, error
 
+try:
+    from groq import Groq
+except ImportError:  # Optional dependency for --llm-provider groq
+    Groq = None
+
 # SQL keywords to exclude from columns
 SQL_KEYWORDS = {
     'SELECT', 'FROM', 'WHERE', 'AND', 'OR', 'NOT', 'IN', 'LIKE', 'IS', 'NULL',
@@ -554,16 +559,8 @@ def _normalize_llm_table_payload(payload: Dict) -> List[Dict]:
     return cleaned
 
 
-def extract_tables_with_columns_llm_chat_completions_batch(
-    sql_items: List[Tuple[int, str]],
-    model: str,
-    api_key: Optional[str],
-    base_url: Optional[str],
-    extra_headers: Optional[Dict[str, str]] = None,
-) -> Dict[int, List[Dict]]:
-    """Extract tables/columns for multiple SQL queries via chat-completions-compatible APIs (OpenAI/OpenRouter/Groq)."""
-    endpoint = (base_url or "https://api.openai.com/v1").rstrip('/') + "/chat/completions"
-
+def _build_batched_sql_prompt(sql_items: List[Tuple[int, str]]) -> Tuple[str, str]:
+    """Build system/user prompts for batched SQL extraction."""
     instructions = (
         "You extract table and column metadata from SQL queries. "
         "Return strict JSON only with this schema: "
@@ -577,12 +574,64 @@ def extract_tables_with_columns_llm_chat_completions_batch(
         lines.append(f"Index {idx}:")
         lines.append(sql)
         lines.append("---")
+    return instructions, "\n".join(lines)
 
+
+
+def extract_tables_with_columns_llm_groq_batch(
+    sql_items: List[Tuple[int, str]],
+    model: str,
+    api_key: str,
+) -> Dict[int, List[Dict]]:
+    """Extract tables/columns for multiple SQL queries via the Groq Python SDK."""
+    if Groq is None:
+        raise RuntimeError("groq package is not installed; install it or use --llm-provider openrouter/openai_compat")
+
+    instructions, user_prompt = _build_batched_sql_prompt(sql_items)
+    client = Groq(api_key=api_key)
+    completion = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": instructions},
+            {"role": "user", "content": user_prompt},
+        ],
+        temperature=0,
+    )
+
+    try:
+        content = completion.choices[0].message.content
+    except (AttributeError, IndexError, TypeError) as exc:
+        raise RuntimeError("Unexpected Groq response shape") from exc
+
+    parsed = _extract_json_object(content)
+    items = parsed.get("items", [])
+    result: Dict[int, List[Dict]] = {}
+    for item in items:
+        try:
+            idx = int(item.get("index"))
+        except (TypeError, ValueError):
+            continue
+        result[idx] = _normalize_llm_table_payload({"tables": item.get("tables", [])})
+    return result
+
+
+
+def extract_tables_with_columns_llm_chat_completions_batch(
+    sql_items: List[Tuple[int, str]],
+    model: str,
+    api_key: Optional[str],
+    base_url: Optional[str],
+    extra_headers: Optional[Dict[str, str]] = None,
+) -> Dict[int, List[Dict]]:
+    """Extract tables/columns for multiple SQL queries via HTTP chat-completions-compatible APIs (OpenAI/OpenRouter)."""
+    endpoint = (base_url or "https://api.openai.com/v1").rstrip('/') + "/chat/completions"
+
+    instructions, user_prompt = _build_batched_sql_prompt(sql_items)
     payload = {
         "model": model,
         "messages": [
             {"role": "system", "content": instructions},
-            {"role": "user", "content": "\n".join(lines)},
+            {"role": "user", "content": user_prompt},
         ],
         "temperature": 0,
     }
@@ -726,13 +775,20 @@ def process_dev_file(
                     for idx in range(batch_start, batch_end)
                 ]
                 try:
-                    batch_result = extract_tables_with_columns_llm_chat_completions_batch(
-                        sql_items,
-                        model=llm_model,
-                        api_key=effective_api_key,
-                        base_url=effective_base_url,
-                        extra_headers=extra_headers or None,
-                    )
+                    if llm_provider == "groq":
+                        batch_result = extract_tables_with_columns_llm_groq_batch(
+                            sql_items,
+                            model=llm_model,
+                            api_key=effective_api_key,
+                        )
+                    else:
+                        batch_result = extract_tables_with_columns_llm_chat_completions_batch(
+                            sql_items,
+                            model=llm_model,
+                            api_key=effective_api_key,
+                            base_url=effective_base_url,
+                            extra_headers=extra_headers or None,
+                        )
                 except Exception as exc:
                     print(
                         f"Warning: LLM batch extraction failed for indexes {batch_start}-{batch_end - 1} ({exc}); "

--- a/dev_with_metadata.json
+++ b/dev_with_metadata.json
@@ -11,28 +11,13 @@
         "name": "frpm",
         "columns": [
           {
-            "name": "County"
-          },
-          {
             "name": "County Name"
           },
           {
             "name": "Enrollment (K-12)"
           },
           {
-            "name": "Free"
-          },
-          {
             "name": "Free Meal Count (K-12)"
-          },
-          {
-            "name": "K"
-          },
-          {
-            "name": "Meal"
-          },
-          {
-            "name": "Name"
           }
         ]
       }
@@ -51,31 +36,13 @@
         "name": "frpm",
         "columns": [
           {
-            "name": "Ages"
-          },
-          {
-            "name": "Educational"
-          },
-          {
             "name": "Educational Option Type"
           },
           {
             "name": "Enrollment (Ages 5-17)"
           },
           {
-            "name": "Free"
-          },
-          {
             "name": "Free Meal Count (Ages 5-17)"
-          },
-          {
-            "name": "Meal"
-          },
-          {
-            "name": "Option"
-          },
-          {
-            "name": "Type"
           }
         ]
       }
@@ -804,28 +771,13 @@
             "name": "CDSCode"
           },
           {
-            "name": "County"
-          },
-          {
             "name": "County Name"
           },
           {
             "name": "FRPM Count (K-12)"
           },
           {
-            "name": "Free"
-          },
-          {
             "name": "Free Meal Count (K-12)"
-          },
-          {
-            "name": "K"
-          },
-          {
-            "name": "Meal"
-          },
-          {
-            "name": "Name"
           }
         ]
       }
@@ -1223,16 +1175,7 @@
             "name": "Enrollment (K-12)"
           },
           {
-            "name": "Free"
-          },
-          {
             "name": "Free Meal Count (K-12)"
-          },
-          {
-            "name": "K"
-          },
-          {
-            "name": "Meal"
           }
         ]
       }
@@ -39541,13 +39484,7 @@
         "name": "Laboratory",
         "columns": [
           {
-            "name": "CHO"
-          },
-          {
             "name": "ID"
-          },
-          {
-            "name": "T"
           },
           {
             "name": "T-CHO"
@@ -39913,22 +39850,10 @@
         "name": "Examination",
         "columns": [
           {
-            "name": "ANA"
-          },
-          {
             "name": "ANA Pattern"
           },
           {
-            "name": "IgM"
-          },
-          {
-            "name": "Pattern"
-          },
-          {
             "name": "Thrombosis"
-          },
-          {
-            "name": "aCL"
           },
           {
             "name": "aCL IgM"
@@ -39951,12 +39876,6 @@
         "columns": [
           {
             "name": "ID"
-          },
-          {
-            "name": "PRO"
-          },
-          {
-            "name": "U"
           },
           {
             "name": "U-PRO"

--- a/dev_with_metadata.json
+++ b/dev_with_metadata.json
@@ -11,13 +11,28 @@
         "name": "frpm",
         "columns": [
           {
+            "name": "County"
+          },
+          {
             "name": "County Name"
           },
           {
             "name": "Enrollment (K-12)"
           },
           {
+            "name": "Free"
+          },
+          {
             "name": "Free Meal Count (K-12)"
+          },
+          {
+            "name": "K"
+          },
+          {
+            "name": "Meal"
+          },
+          {
+            "name": "Name"
           }
         ]
       }
@@ -36,13 +51,31 @@
         "name": "frpm",
         "columns": [
           {
+            "name": "Ages"
+          },
+          {
+            "name": "Educational"
+          },
+          {
             "name": "Educational Option Type"
           },
           {
             "name": "Enrollment (Ages 5-17)"
           },
           {
+            "name": "Free"
+          },
+          {
             "name": "Free Meal Count (Ages 5-17)"
+          },
+          {
+            "name": "Meal"
+          },
+          {
+            "name": "Option"
+          },
+          {
+            "name": "Type"
           }
         ]
       }
@@ -768,13 +801,31 @@
         "name": "frpm",
         "columns": [
           {
+            "name": "CDSCode"
+          },
+          {
+            "name": "County"
+          },
+          {
             "name": "County Name"
           },
           {
             "name": "FRPM Count (K-12)"
           },
           {
+            "name": "Free"
+          },
+          {
             "name": "Free Meal Count (K-12)"
+          },
+          {
+            "name": "K"
+          },
+          {
+            "name": "Meal"
+          },
+          {
+            "name": "Name"
           }
         ]
       }
@@ -797,6 +848,9 @@
           },
           {
             "name": "cname"
+          },
+          {
+            "name": "sname"
           }
         ]
       }
@@ -1169,7 +1223,16 @@
             "name": "Enrollment (K-12)"
           },
           {
+            "name": "Free"
+          },
+          {
             "name": "Free Meal Count (K-12)"
+          },
+          {
+            "name": "K"
+          },
+          {
+            "name": "Meal"
           }
         ]
       }
@@ -1792,7 +1855,16 @@
         "name": "schools",
         "columns": [
           {
+            "name": "County"
+          },
+          {
             "name": "DOC"
+          },
+          {
+            "name": "OpenDate"
+          },
+          {
+            "name": "School"
           }
         ]
       }
@@ -1810,6 +1882,12 @@
       {
         "name": "schools",
         "columns": [
+          {
+            "name": "County"
+          },
+          {
+            "name": "DOC"
+          },
           {
             "name": "StatusType"
           }
@@ -1830,10 +1908,19 @@
         "name": "schools",
         "columns": [
           {
+            "name": "ClosedDate"
+          },
+          {
             "name": "County"
           },
           {
+            "name": "School"
+          },
+          {
             "name": "StatusType"
+          },
+          {
+            "name": "school"
           }
         ]
       }
@@ -1997,6 +2084,15 @@
         "columns": [
           {
             "name": "AdmFName1"
+          },
+          {
+            "name": "AdmLName1"
+          },
+          {
+            "name": "MailZip"
+          },
+          {
+            "name": "School"
           }
         ]
       }
@@ -2014,6 +2110,9 @@
       {
         "name": "schools",
         "columns": [
+          {
+            "name": "County"
+          },
           {
             "name": "MailState"
           }
@@ -2034,7 +2133,16 @@
         "name": "schools",
         "columns": [
           {
+            "name": "CDSCode"
+          },
+          {
             "name": "City"
+          },
+          {
+            "name": "MailState"
+          },
+          {
+            "name": "StatusType"
           }
         ]
       }
@@ -2089,6 +2197,15 @@
         "name": "schools",
         "columns": [
           {
+            "name": "Ext"
+          },
+          {
+            "name": "Phone"
+          },
+          {
+            "name": "School"
+          },
+          {
             "name": "Zip"
           }
         ]
@@ -2106,7 +2223,17 @@
     "tables": [
       {
         "name": "schools",
-        "columns": []
+        "columns": [
+          {
+            "name": "AdmFName1"
+          },
+          {
+            "name": "AdmLName1"
+          },
+          {
+            "name": "Website"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT Website FROM schools WHERE (AdmFName1 = 'Mike' AND AdmLName1 = 'Larson') OR (AdmFName1 = 'Dante' AND AdmLName1 = 'Alvarez')"
@@ -2123,7 +2250,16 @@
         "name": "schools",
         "columns": [
           {
+            "name": "Charter"
+          },
+          {
             "name": "County"
+          },
+          {
+            "name": "Virtual"
+          },
+          {
+            "name": "Website"
           }
         ]
       }
@@ -2142,7 +2278,16 @@
         "name": "schools",
         "columns": [
           {
+            "name": "Charter"
+          },
+          {
+            "name": "City"
+          },
+          {
             "name": "DOC"
+          },
+          {
+            "name": "School"
           }
         ]
       }
@@ -2209,7 +2354,22 @@
         "name": "schools",
         "columns": [
           {
+            "name": "AdmFName1"
+          },
+          {
+            "name": "AdmLName1"
+          },
+          {
             "name": "Charter"
+          },
+          {
+            "name": "CharterNum"
+          },
+          {
+            "name": "City"
+          },
+          {
+            "name": "School"
           }
         ]
       }
@@ -2229,6 +2389,9 @@
         "columns": [
           {
             "name": "CharterNum"
+          },
+          {
+            "name": "MailCity"
           }
         ]
       }
@@ -2247,7 +2410,13 @@
         "name": "schools",
         "columns": [
           {
+            "name": "Charter"
+          },
+          {
             "name": "County"
+          },
+          {
+            "name": "FundingType"
           }
         ]
       }
@@ -2264,7 +2433,20 @@
     "tables": [
       {
         "name": "schools",
-        "columns": []
+        "columns": [
+          {
+            "name": "County"
+          },
+          {
+            "name": "FundingType"
+          },
+          {
+            "name": "OpenDate"
+          },
+          {
+            "name": "School"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(School) FROM schools WHERE TO_CHAR(OpenDate, 'YYYY') BETWEEN '2000' AND '2005' AND County = 'Stanislaus' AND FundingType = 'Directly funded'"
@@ -2279,7 +2461,20 @@
     "tables": [
       {
         "name": "schools",
-        "columns": []
+        "columns": [
+          {
+            "name": "City"
+          },
+          {
+            "name": "ClosedDate"
+          },
+          {
+            "name": "DOCType"
+          },
+          {
+            "name": "School"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(School) FROM schools WHERE TO_CHAR(ClosedDate, 'YYYY') = '1989' AND City = 'San Francisco' AND DOCType = 'Community College District'"
@@ -2296,7 +2491,19 @@
         "name": "schools",
         "columns": [
           {
+            "name": "ClosedDate"
+          },
+          {
             "name": "County"
+          },
+          {
+            "name": "SOC"
+          },
+          {
+            "name": "School"
+          },
+          {
+            "name": "StatusType"
           }
         ]
       }
@@ -2315,6 +2522,9 @@
         "name": "schools",
         "columns": [
           {
+            "name": "NCESDist"
+          },
+          {
             "name": "SOC"
           }
         ]
@@ -2332,7 +2542,20 @@
     "tables": [
       {
         "name": "schools",
-        "columns": []
+        "columns": [
+          {
+            "name": "County"
+          },
+          {
+            "name": "SOC"
+          },
+          {
+            "name": "School"
+          },
+          {
+            "name": "StatusType"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(School) FROM schools WHERE (StatusType = 'Closed' OR StatusType = 'Active') AND SOC = 69 AND County = 'Alpine'"
@@ -2681,6 +2904,9 @@
         "columns": [
           {
             "name": "County"
+          },
+          {
+            "name": "Virtual"
           }
         ]
       }
@@ -2784,7 +3010,14 @@
     "tables": [
       {
         "name": "schools",
-        "columns": []
+        "columns": [
+          {
+            "name": "GSoffered"
+          },
+          {
+            "name": "longitude"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT GSoffered FROM schools ORDER BY ABS(longitude) DESC FETCH FIRST 1 ROWS ONLY"
@@ -2916,7 +3149,19 @@
         "name": "schools",
         "columns": [
           {
+            "name": "AdmLName1"
+          },
+          {
             "name": "CharterNum"
+          },
+          {
+            "name": "County"
+          },
+          {
+            "name": "District"
+          },
+          {
+            "name": "School"
           }
         ]
       }
@@ -3094,7 +3339,14 @@
     "tables": [
       {
         "name": "district",
-        "columns": []
+        "columns": [
+          {
+            "name": "A12"
+          },
+          {
+            "name": "A13"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT DISTINCT IIF(AVG(A13) > AVG(A12), '1996', '1995') FROM district"
@@ -3468,7 +3720,11 @@
     "tables": [
       {
         "name": "trans",
-        "columns": []
+        "columns": [
+          {
+            "name": "account_id"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT account_id FROM trans WHERE TO_CHAR(date, 'YYYY') = '1995' ORDER BY date ASC FETCH FIRST 1 ROWS ONLY"
@@ -4054,7 +4310,14 @@
     "tables": [
       {
         "name": "loan",
-        "columns": []
+        "columns": [
+          {
+            "name": "amount"
+          },
+          {
+            "name": "status"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT (CAST(SUM(CASE WHEN status = 'A' THEN amount ELSE 0 END) AS NUMBER) * 100) / SUM(amount) FROM loan"
@@ -4071,7 +4334,13 @@
         "name": "loan",
         "columns": [
           {
+            "name": "account_id"
+          },
+          {
             "name": "amount"
+          },
+          {
+            "name": "status"
           }
         ]
       }
@@ -4420,6 +4689,9 @@
         "columns": [
           {
             "name": "Frequency"
+          },
+          {
+            "name": "account_id"
           }
         ]
       }
@@ -4665,6 +4937,12 @@
         "columns": [
           {
             "name": "A13"
+          },
+          {
+            "name": "A2"
+          },
+          {
+            "name": "district_id"
           }
         ]
       }
@@ -5506,7 +5784,17 @@
     "tables": [
       {
         "name": "card",
-        "columns": []
+        "columns": [
+          {
+            "name": "card_id"
+          },
+          {
+            "name": "issued"
+          },
+          {
+            "name": "type"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(SUM(type = 'gold' AND TO_CHAR(issued, 'YYYY') < '1998') AS NUMBER) * 100 / COUNT(card_id) FROM card"
@@ -5570,7 +5858,15 @@
             "name": "A15"
           },
           {
-            "name": "account"
+            "name": "district_id"
+          }
+        ]
+      },
+      {
+        "name": "account",
+        "columns": [
+          {
+            "name": "account_id"
           },
           {
             "name": "district_id"
@@ -5596,6 +5892,9 @@
           },
           {
             "name": "district_id"
+          },
+          {
+            "name": "order_id"
           }
         ]
       },
@@ -5606,6 +5905,10 @@
             "name": "district_id"
           }
         ]
+      },
+      {
+        "name": "",
+        "columns": []
       }
     ],
     "oracle_SQL": "SELECT T3.district_id FROM \"order\" AS T1 INNER JOIN account AS T2 ON T1.account_id = T2.account_id INNER JOIN district AS T3 ON T2.district_id = T3.district_id WHERE T1.order_id = 33333"
@@ -5826,6 +6129,9 @@
         "columns": [
           {
             "name": "account_id"
+          },
+          {
+            "name": "order_id"
           }
         ]
       },
@@ -5847,6 +6153,10 @@
             "name": "client_id"
           }
         ]
+      },
+      {
+        "name": "",
+        "columns": []
       }
     ],
     "oracle_SQL": "SELECT T3.client_id FROM \"order\" AS T1 INNER JOIN account AS T2 ON T1.account_id = T2.account_id INNER JOIN disp AS T4 ON T4.account_id = T2.account_id  INNER JOIN client AS T3 ON T4.client_id = T3.client_id WHERE T1.order_id = 32423"
@@ -6062,7 +6372,14 @@
     "tables": [
       {
         "name": "trans",
-        "columns": []
+        "columns": [
+          {
+            "name": "account_id"
+          },
+          {
+            "name": "operation"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(account_id) FROM trans WHERE TO_CHAR(date, 'YYYY') > '1995' AND operation = 'VYBER KARTOU'"
@@ -6077,7 +6394,14 @@
     "tables": [
       {
         "name": "district",
-        "columns": []
+        "columns": [
+          {
+            "name": "A16"
+          },
+          {
+            "name": "A3"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT SUM(CASE WHEN A3 = 'east Bohemia' THEN A16 ELSE 0 END) - SUM(CASE WHEN A3 = 'north Bohemia' THEN A16 ELSE 0 END) FROM district"
@@ -6095,6 +6419,9 @@
         "columns": [
           {
             "name": "account_id"
+          },
+          {
+            "name": "type"
           }
         ]
       }
@@ -6116,7 +6443,16 @@
             "name": "account_id"
           },
           {
+            "name": "amount"
+          },
+          {
             "name": "frequency"
+          },
+          {
+            "name": "k_symbol"
+          },
+          {
+            "name": "total_amount"
           }
         ]
       }
@@ -7071,6 +7407,12 @@
         "name": "bond",
         "columns": [
           {
+            "name": "T"
+          },
+          {
+            "name": "bond_id"
+          },
+          {
             "name": "bond_type"
           }
         ]
@@ -7907,9 +8249,6 @@
         "name": "atom",
         "columns": [
           {
-            "name": "T"
-          },
-          {
             "name": "element"
           },
           {
@@ -7932,6 +8271,12 @@
         "name": "bond",
         "columns": [
           {
+            "name": "atom_id1"
+          },
+          {
+            "name": "atom_id2"
+          },
+          {
             "name": "bond_id"
           },
           {
@@ -7953,6 +8298,9 @@
       {
         "name": "molecule",
         "columns": [
+          {
+            "name": "diff_car_notcar"
+          },
           {
             "name": "label"
           },
@@ -8019,9 +8367,6 @@
       {
         "name": "bond",
         "columns": [
-          {
-            "name": "T"
-          },
           {
             "name": "bond_type"
           },
@@ -8171,6 +8516,9 @@
       {
         "name": "bond",
         "columns": [
+          {
+            "name": "T"
+          },
           {
             "name": "bond_type"
           },
@@ -8551,9 +8899,6 @@
       {
         "name": "molecule",
         "columns": [
-          {
-            "name": "T"
-          },
           {
             "name": "label"
           },
@@ -11108,6 +11453,9 @@
         "name": "molecule",
         "columns": [
           {
+            "name": "label"
+          },
+          {
             "name": "molecule_id"
           }
         ]
@@ -11643,6 +11991,12 @@
         "columns": [
           {
             "name": "cardKingdomFoilId"
+          },
+          {
+            "name": "cardKingdomId"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -11662,6 +12016,12 @@
         "columns": [
           {
             "name": "borderColor"
+          },
+          {
+            "name": "cardKingdomId"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -11681,6 +12041,9 @@
         "columns": [
           {
             "name": "faceConvertedManaCost"
+          },
+          {
+            "name": "name"
           }
         ]
       }
@@ -11700,6 +12063,12 @@
         "columns": [
           {
             "name": "edhrecRank"
+          },
+          {
+            "name": "frameVersion"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -12073,6 +12442,9 @@
         "columns": [
           {
             "name": "artist"
+          },
+          {
+            "name": "type"
           }
         ]
       }
@@ -12091,6 +12463,9 @@
         "name": "cards",
         "columns": [
           {
+            "name": "keywords"
+          },
+          {
             "name": "name"
           }
         ]
@@ -12108,7 +12483,11 @@
     "tables": [
       {
         "name": "cards",
-        "columns": []
+        "columns": [
+          {
+            "name": "power"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(*) FROM cards WHERE power = '*'"
@@ -12126,6 +12505,9 @@
         "columns": [
           {
             "name": "name"
+          },
+          {
+            "name": "promoTypes"
           }
         ]
       }
@@ -12143,6 +12525,9 @@
       {
         "name": "cards",
         "columns": [
+          {
+            "name": "borderColor"
+          },
           {
             "name": "name"
           }
@@ -12164,6 +12549,9 @@
         "columns": [
           {
             "name": "name"
+          },
+          {
+            "name": "originalType"
           }
         ]
       }
@@ -12440,7 +12828,14 @@
     "tables": [
       {
         "name": "cards",
-        "columns": []
+        "columns": [
+          {
+            "name": "borderColor"
+          },
+          {
+            "name": "id"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(SUM(CASE WHEN borderColor = 'borderless' THEN 1 ELSE 0 END) AS NUMBER) * 100 / COUNT(id) FROM cards"
@@ -12565,6 +12960,9 @@
         "name": "cards",
         "columns": [
           {
+            "name": "id"
+          },
+          {
             "name": "toughness"
           }
         ]
@@ -12585,6 +12983,9 @@
         "columns": [
           {
             "name": "artist"
+          },
+          {
+            "name": "name"
           }
         ]
       }
@@ -12604,6 +13005,12 @@
         "columns": [
           {
             "name": "availability"
+          },
+          {
+            "name": "borderColor"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -12623,6 +13030,9 @@
         "columns": [
           {
             "name": "convertedManaCost"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -12642,6 +13052,9 @@
         "columns": [
           {
             "name": "keywords"
+          },
+          {
+            "name": "layout"
           }
         ]
       }
@@ -12660,7 +13073,13 @@
         "name": "cards",
         "columns": [
           {
+            "name": "id"
+          },
+          {
             "name": "originalType"
+          },
+          {
+            "name": "subtypes"
           }
         ]
       }
@@ -12679,7 +13098,13 @@
         "name": "cards",
         "columns": [
           {
+            "name": "cardKingdomFoilId"
+          },
+          {
             "name": "cardKingdomId"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -12699,6 +13124,9 @@
         "columns": [
           {
             "name": "duelDeck"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -12716,6 +13144,9 @@
       {
         "name": "cards",
         "columns": [
+          {
+            "name": "edhrecRank"
+          },
           {
             "name": "frameVersion"
           }
@@ -13133,7 +13564,20 @@
     "tables": [
       {
         "name": "cards",
-        "columns": []
+        "columns": [
+          {
+            "name": "artist"
+          },
+          {
+            "name": "cardKingdomFoilId"
+          },
+          {
+            "name": "cardKingdomId"
+          },
+          {
+            "name": "id"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(id) FROM cards WHERE (cardKingdomId IS NULL OR cardKingdomFoilId IS NULL) AND artist = 'John Avon'"
@@ -13151,6 +13595,15 @@
         "columns": [
           {
             "name": "borderColor"
+          },
+          {
+            "name": "cardKingdomFoilId"
+          },
+          {
+            "name": "cardKingdomId"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -13169,7 +13622,16 @@
         "name": "cards",
         "columns": [
           {
+            "name": "Availability"
+          },
+          {
+            "name": "artist"
+          },
+          {
             "name": "hAND"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -13188,7 +13650,16 @@
         "name": "cards",
         "columns": [
           {
+            "name": "availability"
+          },
+          {
             "name": "frameVersion"
+          },
+          {
+            "name": "hasContentWarning"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -13208,6 +13679,18 @@
         "columns": [
           {
             "name": "availability"
+          },
+          {
+            "name": "borderColor"
+          },
+          {
+            "name": "frameVersion"
+          },
+          {
+            "name": "layout"
+          },
+          {
+            "name": "manaCost"
           }
         ]
       }
@@ -13227,6 +13710,9 @@
         "columns": [
           {
             "name": "artist"
+          },
+          {
+            "name": "manaCost"
           }
         ]
       }
@@ -13246,6 +13732,12 @@
         "columns": [
           {
             "name": "availability"
+          },
+          {
+            "name": "subtypes"
+          },
+          {
+            "name": "supertypes"
           }
         ]
       }
@@ -13265,6 +13757,9 @@
         "columns": [
           {
             "name": "language"
+          },
+          {
+            "name": "setCode"
           }
         ]
       }
@@ -13284,6 +13779,12 @@
         "columns": [
           {
             "name": "frameEffects"
+          },
+          {
+            "name": "id"
+          },
+          {
+            "name": "isOnlineOnly"
           }
         ]
       }
@@ -13302,7 +13803,13 @@
         "name": "cards",
         "columns": [
           {
+            "name": "id"
+          },
+          {
             "name": "isStorySpotlight"
+          },
+          {
+            "name": "isTextless"
           }
         ]
       }
@@ -13840,6 +14347,9 @@
         "columns": [
           {
             "name": "artist"
+          },
+          {
+            "name": "availability"
           }
         ]
       }
@@ -13858,7 +14368,13 @@
         "name": "cards",
         "columns": [
           {
+            "name": "borderColor"
+          },
+          {
             "name": "edhrecRank"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -13877,7 +14393,16 @@
         "name": "cards",
         "columns": [
           {
+            "name": "id"
+          },
+          {
             "name": "isOversized"
+          },
+          {
+            "name": "isPromo"
+          },
+          {
+            "name": "isReprint"
           }
         ]
       }
@@ -13897,6 +14422,12 @@
         "columns": [
           {
             "name": "name"
+          },
+          {
+            "name": "power"
+          },
+          {
+            "name": "promoTypes"
           }
         ]
       }
@@ -13914,6 +14445,9 @@
       {
         "name": "foreign_data",
         "columns": [
+          {
+            "name": "language"
+          },
           {
             "name": "multiverseid"
           }
@@ -13935,6 +14469,9 @@
         "columns": [
           {
             "name": "cardKingdomFoilId"
+          },
+          {
+            "name": "cardKingdomId"
           }
         ]
       }
@@ -13951,7 +14488,14 @@
     "tables": [
       {
         "name": "cards",
-        "columns": []
+        "columns": [
+          {
+            "name": "isTextless"
+          },
+          {
+            "name": "layout"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(SUM(CASE WHEN isTextless = 1 AND layout = 'normal' THEN 1 ELSE 0 END) AS NUMBER) * 100 / COUNT(*) FROM cards"
@@ -13967,6 +14511,12 @@
       {
         "name": "cards",
         "columns": [
+          {
+            "name": "id"
+          },
+          {
+            "name": "side"
+          },
           {
             "name": "subtypes"
           }
@@ -14345,6 +14895,12 @@
         "columns": [
           {
             "name": "borderColor"
+          },
+          {
+            "name": "id"
+          },
+          {
+            "name": "isFullArt"
           }
         ]
       }
@@ -14364,6 +14920,9 @@
         "columns": [
           {
             "name": "id"
+          },
+          {
+            "name": "language"
           }
         ]
       }
@@ -14383,6 +14942,9 @@
         "columns": [
           {
             "name": "code"
+          },
+          {
+            "name": "name"
           }
         ]
       }
@@ -14400,6 +14962,9 @@
       {
         "name": "foreign_data",
         "columns": [
+          {
+            "name": "language"
+          },
           {
             "name": "name"
           }
@@ -14721,7 +15286,17 @@
     "tables": [
       {
         "name": "cards",
-        "columns": []
+        "columns": [
+          {
+            "name": "artist"
+          },
+          {
+            "name": "cardKingdomFoilId"
+          },
+          {
+            "name": "cardKingdomId"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT SUM(CASE WHEN artist = 'Aaron Miller' AND cardKingdomFoilId IS NOT NULL AND cardKingdomId IS NOT NULL THEN 1 ELSE 0 END) FROM cards"
@@ -14736,7 +15311,14 @@
     "tables": [
       {
         "name": "cards",
-        "columns": []
+        "columns": [
+          {
+            "name": "availability"
+          },
+          {
+            "name": "hAND"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT SUM(CASE WHEN availability = 'paper' AND hAND = '3' THEN 1 ELSE 0 END) FROM cards"
@@ -14754,6 +15336,9 @@
         "columns": [
           {
             "name": "isTextless"
+          },
+          {
+            "name": "name"
           }
         ]
       }
@@ -14771,6 +15356,9 @@
       {
         "name": "cards",
         "columns": [
+          {
+            "name": "manaCost"
+          },
           {
             "name": "name"
           }
@@ -14792,6 +15380,9 @@
         "columns": [
           {
             "name": "borderColor"
+          },
+          {
+            "name": "power"
           }
         ]
       }
@@ -14811,6 +15402,12 @@
         "columns": [
           {
             "name": "isPromo"
+          },
+          {
+            "name": "name"
+          },
+          {
+            "name": "side"
           }
         ]
       }
@@ -14830,6 +15427,12 @@
         "columns": [
           {
             "name": "name"
+          },
+          {
+            "name": "subtypes"
+          },
+          {
+            "name": "supertypes"
           }
         ]
       }
@@ -14849,6 +15452,9 @@
         "columns": [
           {
             "name": "promoTypes"
+          },
+          {
+            "name": "purchaseUrls"
           }
         ]
       }
@@ -14865,7 +15471,14 @@
     "tables": [
       {
         "name": "cards",
-        "columns": []
+        "columns": [
+          {
+            "name": "availability"
+          },
+          {
+            "name": "borderColor"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(CASE WHEN availability LIKE '%arena,mtgo%' AND borderColor = 'black' THEN 1 ELSE NULL END) FROM cards"
@@ -14904,6 +15517,9 @@
         "name": "cards",
         "columns": [
           {
+            "name": "artist"
+          },
+          {
             "name": "flavorName"
           }
         ]
@@ -14927,6 +15543,9 @@
           },
           {
             "name": "frameVersion"
+          },
+          {
+            "name": "name"
           }
         ]
       }
@@ -15853,6 +16472,9 @@
         "name": "sets",
         "columns": [
           {
+            "name": "code"
+          },
+          {
             "name": "releaseDate"
           }
         ]
@@ -15873,6 +16495,9 @@
         "columns": [
           {
             "name": "code"
+          },
+          {
+            "name": "keyruneCode"
           }
         ]
       }
@@ -15892,6 +16517,9 @@
         "columns": [
           {
             "name": "code"
+          },
+          {
+            "name": "mcmId"
           }
         ]
       }
@@ -15909,6 +16537,9 @@
       {
         "name": "sets",
         "columns": [
+          {
+            "name": "mcmName"
+          },
           {
             "name": "releaseDate"
           }
@@ -15953,6 +16584,9 @@
         "columns": [
           {
             "name": "name"
+          },
+          {
+            "name": "parentCode"
           }
         ]
       }
@@ -16401,6 +17035,12 @@
         "columns": [
           {
             "name": "artist"
+          },
+          {
+            "name": "availability"
+          },
+          {
+            "name": "isTextless"
           }
         ]
       }
@@ -16420,6 +17060,9 @@
         "columns": [
           {
             "name": "baseSetSize"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -16437,6 +17080,9 @@
       {
         "name": "cards",
         "columns": [
+          {
+            "name": "artist"
+          },
           {
             "name": "convertedManaCost"
           },
@@ -16463,6 +17109,9 @@
             "name": "cardKingdomFoilId"
           },
           {
+            "name": "cardKingdomId"
+          },
+          {
             "name": "frameEffects"
           }
         ]
@@ -16482,7 +17131,13 @@
         "name": "cards",
         "columns": [
           {
+            "name": "duelDeck"
+          },
+          {
             "name": "hasFoil"
+          },
+          {
+            "name": "power"
           }
         ]
       }
@@ -16500,6 +17155,9 @@
       {
         "name": "sets",
         "columns": [
+          {
+            "name": "id"
+          },
           {
             "name": "totalSetSize"
           },
@@ -16889,6 +17547,12 @@
         "name": "cards",
         "columns": [
           {
+            "name": "BorderColor"
+          },
+          {
+            "name": "artist"
+          },
+          {
             "name": "availability"
           }
         ]
@@ -16909,6 +17573,12 @@
         "columns": [
           {
             "name": "format"
+          },
+          {
+            "name": "status"
+          },
+          {
+            "name": "uuid"
           }
         ]
       }
@@ -16928,6 +17598,12 @@
         "columns": [
           {
             "name": "artist"
+          },
+          {
+            "name": "availability"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -17085,6 +17761,9 @@
         "columns": [
           {
             "name": "DisplayName"
+          },
+          {
+            "name": "Reputation"
           }
         ]
       }
@@ -17101,7 +17780,14 @@
     "tables": [
       {
         "name": "users",
-        "columns": []
+        "columns": [
+          {
+            "name": "CreationDate"
+          },
+          {
+            "name": "DisplayName"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT DisplayName FROM users WHERE TO_CHAR(CreationDate, 'YYYY') = '2011'"
@@ -17116,7 +17802,14 @@
     "tables": [
       {
         "name": "users",
-        "columns": []
+        "columns": [
+          {
+            "name": "Id"
+          },
+          {
+            "name": "LastAccessDate"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(Id) FROM users WHERE date(LastAccessDate) > '2014-09-01'"
@@ -17132,6 +17825,9 @@
       {
         "name": "users",
         "columns": [
+          {
+            "name": "DisplayName"
+          },
           {
             "name": "Views"
           }
@@ -17152,6 +17848,12 @@
         "name": "users",
         "columns": [
           {
+            "name": "Downvotes"
+          },
+          {
+            "name": "Id"
+          },
+          {
             "name": "Upvotes"
           }
         ]
@@ -17169,7 +17871,17 @@
     "tables": [
       {
         "name": "users",
-        "columns": []
+        "columns": [
+          {
+            "name": "CreationDate"
+          },
+          {
+            "name": "Views"
+          },
+          {
+            "name": "id"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(id) FROM users WHERE TO_CHAR(CreationDate, 'YYYY') > '2013' AND Views > 10"
@@ -17707,7 +18419,7 @@
         ]
       }
     ],
-    "oracle_SQL": "SELECT T1.Name FROM badges AS T1 INNER JOIN users AS T2 ON T1.UserId = T2.Id WHERE T2.DisplayName = 'csgillespie'"
+    "oracle_SQL": "SELECT T1.\"Name\" FROM badges AS T1 INNER JOIN users AS T2 ON T1.UserId = T2.Id WHERE T2.DisplayName = 'csgillespie'"
   },
   {
     "question_id": 553,
@@ -17892,6 +18604,12 @@
         "name": "votes",
         "columns": [
           {
+            "name": "CreationDate"
+          },
+          {
+            "name": "Id"
+          },
+          {
             "name": "UserId"
           }
         ]
@@ -17912,6 +18630,9 @@
         "columns": [
           {
             "name": "CreationDate"
+          },
+          {
+            "name": "Id"
           }
         ]
       }
@@ -17929,6 +18650,9 @@
       {
         "name": "badges",
         "columns": [
+          {
+            "name": "Id"
+          },
           {
             "name": "Name"
           }
@@ -18303,6 +19027,9 @@
         "columns": [
           {
             "name": "Title"
+          },
+          {
+            "name": "ViewCount"
           }
         ]
       }
@@ -18339,6 +19066,9 @@
       {
         "name": "users",
         "columns": [
+          {
+            "name": "DisplayName"
+          },
           {
             "name": "WebsiteUrl"
           }
@@ -18806,6 +19536,9 @@
         "name": "comments",
         "columns": [
           {
+            "name": "Id"
+          },
+          {
             "name": "UserId"
           }
         ]
@@ -18824,6 +19557,9 @@
       {
         "name": "users",
         "columns": [
+          {
+            "name": "Id"
+          },
           {
             "name": "Reputation"
           }
@@ -18844,6 +19580,9 @@
         "name": "users",
         "columns": [
           {
+            "name": "Id"
+          },
+          {
             "name": "Views"
           }
         ]
@@ -18861,7 +19600,14 @@
     "tables": [
       {
         "name": "badges",
-        "columns": []
+        "columns": [
+          {
+            "name": "Id"
+          },
+          {
+            "name": "Name"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(Id) FROM badges WHERE TO_CHAR(Date, 'YYYY') = '2011' AND Name = 'Supporter'"
@@ -18878,7 +19624,16 @@
         "name": "badges",
         "columns": [
           {
+            "name": "Name"
+          },
+          {
+            "name": "T"
+          },
+          {
             "name": "UserId"
+          },
+          {
+            "name": "num"
           }
         ]
       }
@@ -19073,6 +19828,9 @@
         "name": "badges",
         "columns": [
           {
+            "name": "Id"
+          },
+          {
             "name": "Name"
           }
         ]
@@ -19266,6 +20024,9 @@
         "columns": [
           {
             "name": "Name"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -19282,7 +20043,11 @@
     "tables": [
       {
         "name": "badges",
-        "columns": []
+        "columns": [
+          {
+            "name": "Name"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT Name FROM badges WHERE Date = '2010-07-19 19:39:08.0'"
@@ -19298,6 +20063,9 @@
       {
         "name": "comments",
         "columns": [
+          {
+            "name": "id"
+          },
           {
             "name": "score"
           }
@@ -19338,6 +20106,9 @@
         "columns": [
           {
             "name": "Score"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -19534,7 +20305,7 @@
         ]
       }
     ],
-    "oracle_SQL": "SELECT CAST(SUM(CASE WHEN T2.Age BETWEEN 13 AND 18 THEN 1 ELSE 0 END) AS NUMBER) * 100 / COUNT(T1.Id) FROM badges AS T1 INNER JOIN users AS T2 ON T1.UserId = T2.Id WHERE T1.Name = 'Organizer'"
+    "oracle_SQL": "SELECT CAST(SUM(CASE WHEN T2.Age BETWEEN 13 AND 18 THEN 1 ELSE 0 END) AS NUMBER) * 100 / COUNT(T1.Id) FROM badges AS T1 INNER JOIN users AS T2 ON T1.UserId = T2.Id WHERE T1.\"Name\" = 'Organizer'"
   },
   {
     "question_id": 616,
@@ -19806,6 +20577,9 @@
         "name": "users",
         "columns": [
           {
+            "name": "DisplayName"
+          },
+          {
             "name": "Id"
           }
         ]
@@ -19825,6 +20599,9 @@
         "name": "users",
         "columns": [
           {
+            "name": "Id"
+          },
+          {
             "name": "Location"
           }
         ]
@@ -19842,7 +20619,14 @@
     "tables": [
       {
         "name": "votes",
-        "columns": []
+        "columns": [
+          {
+            "name": "CreationDate"
+          },
+          {
+            "name": "id"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(id) FROM votes WHERE TO_CHAR(CreationDate, 'YYYY') = '2010'"
@@ -19860,6 +20644,9 @@
         "columns": [
           {
             "name": "Age"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -19878,6 +20665,12 @@
         "name": "users",
         "columns": [
           {
+            "name": "DisplayName"
+          },
+          {
+            "name": "Id"
+          },
+          {
             "name": "Views"
           }
         ]
@@ -19895,7 +20688,11 @@
     "tables": [
       {
         "name": "votes",
-        "columns": []
+        "columns": [
+          {
+            "name": "CreationDate"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(SUM(IIF(TO_CHAR(CreationDate, 'YYYY') = '2010', 1, 0)) AS NUMBER) / SUM(IIF(TO_CHAR(CreationDate, 'YYYY') = '2011', 1, 0)) FROM votes"
@@ -20280,7 +21077,7 @@
         ]
       }
     ],
-    "oracle_SQL": "SELECT T1.DisplayName FROM users AS T1 INNER JOIN badges AS T2 ON T1.Id = T2.UserId WHERE T2.Name = 'Organizer'"
+    "oracle_SQL": "SELECT T1.DisplayName FROM users AS T1 INNER JOIN badges AS T2 ON T1.Id = T2.UserId WHERE T2.\"Name\" = 'Organizer'"
   },
   {
     "question_id": 639,
@@ -20382,6 +21179,9 @@
         "name": "badges",
         "columns": [
           {
+            "name": "Id"
+          },
+          {
             "name": "Name"
           }
         ]
@@ -20399,7 +21199,14 @@
     "tables": [
       {
         "name": "postHistory",
-        "columns": []
+        "columns": [
+          {
+            "name": "CreationDate"
+          },
+          {
+            "name": "id"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(id) FROM postHistory WHERE date(CreationDate) = '2010-07-21'"
@@ -20415,6 +21222,12 @@
       {
         "name": "users",
         "columns": [
+          {
+            "name": "Age"
+          },
+          {
+            "name": "DisplayName"
+          },
           {
             "name": "Views"
           }
@@ -20435,6 +21248,12 @@
         "name": "posts",
         "columns": [
           {
+            "name": "LastEditDate"
+          },
+          {
+            "name": "LastEditorUserId"
+          },
+          {
             "name": "Title"
           }
         ]
@@ -20453,6 +21272,12 @@
       {
         "name": "comments",
         "columns": [
+          {
+            "name": "Id"
+          },
+          {
+            "name": "Score"
+          },
           {
             "name": "UserId"
           }
@@ -20889,6 +21714,9 @@
         "name": "posts",
         "columns": [
           {
+            "name": "Title"
+          },
+          {
             "name": "ViewCount"
           }
         ]
@@ -20906,7 +21734,11 @@
     "tables": [
       {
         "name": "tags",
-        "columns": []
+        "columns": [
+          {
+            "name": "Id"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(Id) FROM tags WHERE Count BETWEEN 5000 AND 7000"
@@ -20924,6 +21756,9 @@
         "columns": [
           {
             "name": "FavoriteCount"
+          },
+          {
+            "name": "OwnerUserId"
           }
         ]
       }
@@ -20941,6 +21776,9 @@
       {
         "name": "users",
         "columns": [
+          {
+            "name": "Age"
+          },
           {
             "name": "Reputation"
           }
@@ -20995,6 +21833,9 @@
         "columns": [
           {
             "name": "Age"
+          },
+          {
+            "name": "Id"
           }
         ]
       }
@@ -21014,6 +21855,9 @@
         "columns": [
           {
             "name": "LasActivityDate"
+          },
+          {
+            "name": "Score"
           }
         ]
       }
@@ -21249,7 +22093,7 @@
         ]
       }
     ],
-    "oracle_SQL": "SELECT T1.DisplayName FROM users AS T1 INNER JOIN badges AS T2 ON T1.Id = T2.UserId WHERE T2.Name = 'Autobiographer' ORDER BY T2.Date FETCH FIRST 1 ROWS ONLY"
+    "oracle_SQL": "SELECT T1.DisplayName FROM users AS T1 INNER JOIN badges AS T2 ON T1.Id = T2.UserId WHERE T2.\"Name\" = 'Autobiographer' ORDER BY T2.Date FETCH FIRST 1 ROWS ONLY"
   },
   {
     "question_id": 672,
@@ -21322,6 +22166,9 @@
         "name": "users",
         "columns": [
           {
+            "name": "DisplayName"
+          },
+          {
             "name": "Reputation"
           }
         ]
@@ -21342,6 +22189,12 @@
         "columns": [
           {
             "name": "Reputation"
+          },
+          {
+            "name": "Views"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -21361,6 +22214,9 @@
         "columns": [
           {
             "name": "Age"
+          },
+          {
+            "name": "DisplayName"
           }
         ]
       }
@@ -21620,7 +22476,14 @@
     "tables": [
       {
         "name": "users",
-        "columns": []
+        "columns": [
+          {
+            "name": "Age"
+          },
+          {
+            "name": "Id"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(SUM(CASE WHEN Age BETWEEN 13 AND 18 THEN 1 ELSE 0 END) AS NUMBER) * 100 / COUNT(Id) FROM users"
@@ -21681,6 +22544,9 @@
         "name": "posts",
         "columns": [
           {
+            "name": "Id"
+          },
+          {
             "name": "ViewCount"
           }
         ]
@@ -21732,6 +22598,12 @@
       {
         "name": "posts",
         "columns": [
+          {
+            "name": "CommentCount"
+          },
+          {
+            "name": "Id"
+          },
           {
             "name": "ViewCount"
           }
@@ -21825,6 +22697,12 @@
         "columns": [
           {
             "name": "Age"
+          },
+          {
+            "name": "Id"
+          },
+          {
+            "name": "UpVotes"
           }
         ]
       }
@@ -21965,11 +22843,14 @@
         "columns": [
           {
             "name": "Name"
+          },
+          {
+            "name": "id"
           }
         ]
       }
     ],
-    "oracle_SQL": "SELECT COUNT(id) FROM badges WHERE Name = 'Citizen Patrol'"
+    "oracle_SQL": "SELECT COUNT(id) FROM badges WHERE \"Name\" = 'Citizen Patrol'"
   },
   {
     "question_id": 696,
@@ -21982,6 +22863,9 @@
       {
         "name": "tags",
         "columns": [
+          {
+            "name": "Id"
+          },
           {
             "name": "TagName"
           }
@@ -22003,6 +22887,12 @@
         "columns": [
           {
             "name": "DisplayName"
+          },
+          {
+            "name": "Reputation"
+          },
+          {
+            "name": "Views"
           }
         ]
       }
@@ -22020,6 +22910,12 @@
       {
         "name": "posts",
         "columns": [
+          {
+            "name": "AnswerCount"
+          },
+          {
+            "name": "CommentCount"
+          },
           {
             "name": "Title"
           }
@@ -22039,6 +22935,9 @@
       {
         "name": "users",
         "columns": [
+          {
+            "name": "CreationDate"
+          },
           {
             "name": "DisplayName"
           }
@@ -22060,6 +22959,9 @@
         "columns": [
           {
             "name": "BountyAmount"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -22112,6 +23014,9 @@
         "columns": [
           {
             "name": "Score"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -22128,7 +23033,14 @@
     "tables": [
       {
         "name": "tags",
-        "columns": []
+        "columns": [
+          {
+            "name": "Id"
+          },
+          {
+            "name": "id"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(id) FROM tags WHERE Count <= 20 AND Id < 15"
@@ -22145,7 +23057,13 @@
         "name": "tags",
         "columns": [
           {
+            "name": "ExcerptPostId"
+          },
+          {
             "name": "TagName"
+          },
+          {
+            "name": "WikiPostId"
           }
         ]
       }
@@ -22903,9 +23821,6 @@
             "name": "height_cm"
           },
           {
-            "name": "publ"
-          },
-          {
             "name": "publisher_id"
           }
         ]
@@ -22973,9 +23888,6 @@
           },
           {
             "name": "id"
-          },
-          {
-            "name": "publ"
           },
           {
             "name": "publisher_id"
@@ -23680,6 +24592,9 @@
         "name": "publisher",
         "columns": [
           {
+            "name": "id"
+          },
+          {
             "name": "publisher_name"
           }
         ]
@@ -23697,7 +24612,11 @@
     "tables": [
       {
         "name": "hero_attribute",
-        "columns": []
+        "columns": [
+          {
+            "name": "attribute_value"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT AVG(attribute_value) FROM hero_attribute"
@@ -23715,6 +24634,9 @@
         "columns": [
           {
             "name": "full_name"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -25327,7 +26249,13 @@
         "name": "superhero",
         "columns": [
           {
+            "name": "CALCULATE"
+          },
+          {
             "name": "full_name"
+          },
+          {
+            "name": "weight_kg"
           }
         ]
       }
@@ -25344,7 +26272,14 @@
     "tables": [
       {
         "name": "superhero",
-        "columns": []
+        "columns": [
+          {
+            "name": "height_cm"
+          },
+          {
+            "name": "id"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(SUM(height_cm) AS NUMBER) / COUNT(id) FROM superhero"
@@ -25736,6 +26671,9 @@
         "columns": [
           {
             "name": "height_cm"
+          },
+          {
+            "name": "superhero_name"
           }
         ]
       }
@@ -25753,6 +26691,9 @@
       {
         "name": "superpower",
         "columns": [
+          {
+            "name": "id"
+          },
           {
             "name": "power_name"
           }
@@ -25774,6 +26715,9 @@
         "columns": [
           {
             "name": "id"
+          },
+          {
+            "name": "superhero_name"
           }
         ]
       }
@@ -25793,6 +26737,9 @@
         "columns": [
           {
             "name": "full_name"
+          },
+          {
+            "name": "weight_kg"
           }
         ]
       }
@@ -26920,6 +27867,9 @@
         "columns": [
           {
             "name": "height_cm"
+          },
+          {
+            "name": "superhero_name"
           }
         ]
       }
@@ -26939,6 +27889,9 @@
         "columns": [
           {
             "name": "full_name"
+          },
+          {
+            "name": "superhero_name"
           }
         ]
       }
@@ -27052,6 +28005,9 @@
         "columns": [
           {
             "name": "full_name"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -27071,6 +28027,9 @@
         "columns": [
           {
             "name": "attribute_value"
+          },
+          {
+            "name": "hero_id"
           }
         ]
       }
@@ -27088,6 +28047,9 @@
       {
         "name": "superhero",
         "columns": [
+          {
+            "name": "full_name"
+          },
           {
             "name": "superhero_name"
           }
@@ -28656,7 +29618,11 @@
     "tables": [
       {
         "name": "races",
-        "columns": []
+        "columns": [
+          {
+            "name": "name"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT name FROM races WHERE TO_CHAR(date, 'YYYY') = ( SELECT TO_CHAR(date, 'YYYY') FROM races ORDER BY date ASC LIMIT 1 ) AND TO_CHAR(date, 'MM') = ( SELECT TO_CHAR(date, 'MM') FROM races ORDER BY date ASC LIMIT 1 )"
@@ -28671,7 +29637,11 @@
     "tables": [
       {
         "name": "races",
-        "columns": []
+        "columns": [
+          {
+            "name": "name"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT name, date FROM races WHERE year = 1999 ORDER BY round DESC FETCH FIRST 1 ROWS ONLY"
@@ -28701,7 +29671,11 @@
     "tables": [
       {
         "name": "races",
-        "columns": []
+        "columns": [
+          {
+            "name": "name"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT name FROM races WHERE year = 2017 AND name NOT IN ( SELECT name FROM races WHERE year = 2000 )"
@@ -29159,10 +30133,19 @@
         "name": "drivers",
         "columns": [
           {
+            "name": "CURRENT_TIMESTAMP"
+          },
+          {
             "name": "dob"
           },
           {
+            "name": "forename"
+          },
+          {
             "name": "nationality"
+          },
+          {
+            "name": "surname"
           }
         ]
       }
@@ -29663,6 +30646,12 @@
         "name": "circuits",
         "columns": [
           {
+            "name": "lat"
+          },
+          {
+            "name": "lng"
+          },
+          {
             "name": "name"
           }
         ]
@@ -29704,6 +30693,9 @@
         "name": "circuits",
         "columns": [
           {
+            "name": "circuitRef"
+          },
+          {
             "name": "name"
           }
         ]
@@ -29724,6 +30716,9 @@
         "columns": [
           {
             "name": "alt"
+          },
+          {
+            "name": "country"
           }
         ]
       }
@@ -29740,7 +30735,14 @@
     "tables": [
       {
         "name": "drivers",
-        "columns": []
+        "columns": [
+          {
+            "name": "code"
+          },
+          {
+            "name": "driverId"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(driverId) - COUNT(CASE WHEN code IS NOT NULL THEN code END) FROM drivers"
@@ -29758,6 +30760,9 @@
         "columns": [
           {
             "name": "dob"
+          },
+          {
+            "name": "nationality"
           }
         ]
       }
@@ -29777,6 +30782,9 @@
         "columns": [
           {
             "name": "nationality"
+          },
+          {
+            "name": "surname"
           }
         ]
       }
@@ -29796,6 +30804,12 @@
         "columns": [
           {
             "name": "forename"
+          },
+          {
+            "name": "surname"
+          },
+          {
+            "name": "url"
           }
         ]
       }
@@ -29814,7 +30828,13 @@
         "name": "drivers",
         "columns": [
           {
+            "name": "driverRef"
+          },
+          {
             "name": "forename"
+          },
+          {
+            "name": "surname"
           }
         ]
       }
@@ -30833,6 +31853,12 @@
         "name": "circuits",
         "columns": [
           {
+            "name": "circuitId"
+          },
+          {
+            "name": "country"
+          },
+          {
             "name": "location"
           }
         ]
@@ -30853,6 +31879,12 @@
         "columns": [
           {
             "name": "country"
+          },
+          {
+            "name": "lat"
+          },
+          {
+            "name": "lng"
           }
         ]
       }
@@ -30870,6 +31902,12 @@
       {
         "name": "drivers",
         "columns": [
+          {
+            "name": "dob"
+          },
+          {
+            "name": "driverId"
+          },
           {
             "name": "nationality"
           }
@@ -31449,6 +32487,9 @@
         "columns": [
           {
             "name": "Nationality"
+          },
+          {
+            "name": "code"
           }
         ]
       }
@@ -31465,7 +32506,11 @@
     "tables": [
       {
         "name": "races",
-        "columns": []
+        "columns": [
+          {
+            "name": "raceId"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT raceId FROM races WHERE year = 2009"
@@ -31481,6 +32526,9 @@
       {
         "name": "driverStandings",
         "columns": [
+          {
+            "name": "driverId"
+          },
           {
             "name": "raceId"
           }
@@ -31523,7 +32571,13 @@
         "name": "drivers",
         "columns": [
           {
+            "name": "driverRef"
+          },
+          {
             "name": "forename"
+          },
+          {
+            "name": "surname"
           }
         ]
       }
@@ -31541,6 +32595,12 @@
       {
         "name": "drivers",
         "columns": [
+          {
+            "name": "dob"
+          },
+          {
+            "name": "driverId"
+          },
           {
             "name": "nationality"
           }
@@ -31593,6 +32653,12 @@
       {
         "name": "drivers",
         "columns": [
+          {
+            "name": "dob"
+          },
+          {
+            "name": "driverRef"
+          },
           {
             "name": "nationality"
           }
@@ -31739,6 +32805,9 @@
         "name": "lapTimes",
         "columns": [
           {
+            "name": "driverId"
+          },
+          {
             "name": "lap"
           }
         ]
@@ -31757,6 +32826,12 @@
       {
         "name": "results",
         "columns": [
+          {
+            "name": "raceID"
+          },
+          {
+            "name": "raceId"
+          },
           {
             "name": "statusId"
           }
@@ -31778,6 +32853,15 @@
         "columns": [
           {
             "name": "country"
+          },
+          {
+            "name": "lat"
+          },
+          {
+            "name": "lng"
+          },
+          {
+            "name": "location"
           }
         ]
       }
@@ -32238,7 +33322,16 @@
         "name": "drivers",
         "columns": [
           {
+            "name": "dob"
+          },
+          {
+            "name": "forename"
+          },
+          {
             "name": "nationality"
+          },
+          {
+            "name": "surname"
           }
         ]
       }
@@ -32260,7 +33353,16 @@
             "name": "dob"
           },
           {
+            "name": "forename"
+          },
+          {
             "name": "nationality"
+          },
+          {
+            "name": "surname"
+          },
+          {
+            "name": "url"
           }
         ]
       }
@@ -32278,6 +33380,15 @@
       {
         "name": "circuits",
         "columns": [
+          {
+            "name": "country"
+          },
+          {
+            "name": "lat"
+          },
+          {
+            "name": "lng"
+          },
           {
             "name": "name"
           }
@@ -32413,6 +33524,9 @@
         "name": "drivers",
         "columns": [
           {
+            "name": "driverId"
+          },
+          {
             "name": "nationality"
           }
         ]
@@ -32430,7 +33544,14 @@
     "tables": [
       {
         "name": "driverStandings",
-        "columns": []
+        "columns": [
+          {
+            "name": "points"
+          },
+          {
+            "name": "wins"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT SUM(CASE WHEN points = 91 THEN wins ELSE 0 END) FROM driverStandings"
@@ -32887,7 +34008,11 @@
     "tables": [
       {
         "name": "lapTimes",
-        "columns": []
+        "columns": [
+          {
+            "name": "min_time_in_seconds"
+          }
+        ]
       },
       {
         "name": "lap_times_in_seconds",
@@ -33337,6 +34462,9 @@
         "columns": [
           {
             "name": "overall_rating"
+          },
+          {
+            "name": "player_api_id"
           }
         ]
       }
@@ -33356,6 +34484,9 @@
         "columns": [
           {
             "name": "height"
+          },
+          {
+            "name": "player_name"
           }
         ]
       }
@@ -33375,6 +34506,9 @@
         "columns": [
           {
             "name": "potential"
+          },
+          {
+            "name": "preferred_foot"
           }
         ]
       }
@@ -33392,6 +34526,12 @@
       {
         "name": "Player_Attributes",
         "columns": [
+          {
+            "name": "defensive_work_rate"
+          },
+          {
+            "name": "id"
+          },
           {
             "name": "overall_rating"
           }
@@ -33413,6 +34553,9 @@
         "columns": [
           {
             "name": "crossing"
+          },
+          {
+            "name": "id"
           }
         ]
       }
@@ -33427,6 +34570,23 @@
     "SQL": "SELECT t2.name FROM Match AS t1 INNER JOIN League AS t2 ON t1.league_id = t2.id WHERE t1.season = '2015/2016' GROUP BY t2.name ORDER BY SUM(t1.home_team_goal + t1.away_team_goal) DESC LIMIT 1",
     "difficulty": "moderate",
     "tables": [
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "away_team_goal"
+          },
+          {
+            "name": "home_team_goal"
+          },
+          {
+            "name": "league_id"
+          },
+          {
+            "name": "season"
+          }
+        ]
+      },
       {
         "name": "League",
         "columns": [
@@ -33450,11 +34610,25 @@
     "difficulty": "moderate",
     "tables": [
       {
-        "name": "Team",
+        "name": "Match",
         "columns": [
           {
-            "name": "matchData"
+            "name": "away_team_goal"
           },
+          {
+            "name": "home_team_api_id"
+          },
+          {
+            "name": "home_team_goal"
+          },
+          {
+            "name": "season"
+          }
+        ]
+      },
+      {
+        "name": "Team",
+        "columns": [
           {
             "name": "team_api_id"
           },
@@ -33514,10 +34688,27 @@
             "name": "id"
           },
           {
-            "name": "matchData"
+            "name": "name"
+          }
+        ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "away_team_api_id"
           },
           {
-            "name": "name"
+            "name": "away_team_goal"
+          },
+          {
+            "name": "home_team_goal"
+          },
+          {
+            "name": "league_id"
+          },
+          {
+            "name": "season"
           }
         ]
       },
@@ -33573,6 +34764,26 @@
     "SQL": "SELECT t2.name FROM Match AS t1 INNER JOIN League AS t2 ON t1.league_id = t2.id WHERE t1.season = '2015/2016' AND t1.home_team_goal = t1.away_team_goal GROUP BY t2.name ORDER BY COUNT(t1.id) DESC LIMIT 1",
     "difficulty": "moderate",
     "tables": [
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "away_team_goal"
+          },
+          {
+            "name": "home_team_goal"
+          },
+          {
+            "name": "id"
+          },
+          {
+            "name": "league_id"
+          },
+          {
+            "name": "season"
+          }
+        ]
+      },
       {
         "name": "League",
         "columns": [
@@ -33641,6 +34852,10 @@
             "name": "name"
           }
         ]
+      },
+      {
+        "name": "Match",
+        "columns": []
       }
     ],
     "oracle_SQL": "SELECT t2.name, t1.max_count FROM League AS t2 JOIN (SELECT league_id, MAX(cnt) AS max_count FROM (SELECT league_id, COUNT(id) AS cnt FROM Match GROUP BY league_id) AS subquery) AS t1 ON t1.league_id = t2.id"
@@ -33655,7 +34870,17 @@
     "tables": [
       {
         "name": "Player",
-        "columns": []
+        "columns": [
+          {
+            "name": "birthday"
+          },
+          {
+            "name": "height"
+          },
+          {
+            "name": "id"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT SUM(height) / COUNT(id) FROM Player WHERE SUBSTR(birthday, 1, 4) BETWEEN '1990' AND '1995'"
@@ -33673,6 +34898,9 @@
         "columns": [
           {
             "name": "overall_rating"
+          },
+          {
+            "name": "player_api_id"
           }
         ]
       }
@@ -33692,6 +34920,9 @@
         "columns": [
           {
             "name": "buildUpPlaySpeed"
+          },
+          {
+            "name": "team_fifa_api_id"
           }
         ]
       }
@@ -33786,6 +35017,20 @@
           },
           {
             "name": "name"
+          }
+        ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "away_team_goal"
+          },
+          {
+            "name": "home_team_goal"
+          },
+          {
+            "name": "league_id"
           }
         ]
       }
@@ -33924,6 +35169,26 @@
             "name": "name"
           }
         ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "away_team_goal"
+          },
+          {
+            "name": "home_team_goal"
+          },
+          {
+            "name": "id"
+          },
+          {
+            "name": "league_id"
+          },
+          {
+            "name": "season"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT t1.name FROM League AS t1 INNER JOIN Match AS t2 ON t1.id = t2.league_id WHERE t2.season = '2009/2010' GROUP BY t1.name HAVING (CAST(SUM(t2.home_team_goal) AS NUMBER) / COUNT(DISTINCT t2.id)) - (CAST(SUM(t2.away_team_goal) AS NUMBER) / COUNT(DISTINCT t2.id)) > 0"
@@ -33941,6 +35206,9 @@
         "columns": [
           {
             "name": "team_long_name"
+          },
+          {
+            "name": "team_short_name"
           }
         ]
       }
@@ -33957,7 +35225,14 @@
     "tables": [
       {
         "name": "Player",
-        "columns": []
+        "columns": [
+          {
+            "name": "birthday"
+          },
+          {
+            "name": "player_name"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT player_name FROM Player WHERE SUBSTR(birthday, 1, 7) = '1970-10'"
@@ -34110,6 +35385,20 @@
           },
           {
             "name": "name"
+          }
+        ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "id"
+          },
+          {
+            "name": "league_id"
+          },
+          {
+            "name": "season"
           }
         ]
       }
@@ -34368,6 +35657,23 @@
             "name": "name"
           }
         ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "country_id"
+          },
+          {
+            "name": "home_team_goal"
+          },
+          {
+            "name": "id"
+          },
+          {
+            "name": "season"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(SUM(t2.home_team_goal) AS NUMBER) / COUNT(t2.id) FROM Country AS t1 INNER JOIN Match AS t2 ON t1.id = t2.country_id WHERE t1.name = 'Poland' AND t2.season = '2010/2011'"
@@ -34418,6 +35724,9 @@
         "columns": [
           {
             "name": "height"
+          },
+          {
+            "name": "player_name"
           }
         ]
       }
@@ -34434,7 +35743,14 @@
     "tables": [
       {
         "name": "Player",
-        "columns": []
+        "columns": [
+          {
+            "name": "birthday"
+          },
+          {
+            "name": "id"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(id) FROM Player WHERE TO_CHAR(birthday, 'YYYY') > '1990'"
@@ -34450,6 +35766,12 @@
       {
         "name": "Player",
         "columns": [
+          {
+            "name": "id"
+          },
+          {
+            "name": "player_name"
+          },
           {
             "name": "weight"
           }
@@ -34708,6 +36030,9 @@
         "columns": [
           {
             "name": "height"
+          },
+          {
+            "name": "player_name"
           }
         ]
       }
@@ -34840,6 +36165,17 @@
             "name": "name"
           }
         ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "id"
+          },
+          {
+            "name": "league_id"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(t2.id) FROM League AS t1 INNER JOIN Match AS t2 ON t1.id = t2.league_id WHERE t1.name = 'Germany 1. Bundesliga' AND SUBSTR(t2.\"date\", 1, 7) BETWEEN '2008-08' AND '2008-10'"
@@ -34860,6 +36196,17 @@
           },
           {
             "name": "team_short_name"
+          }
+        ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "home_team_api_id"
+          },
+          {
+            "name": "home_team_goal"
           }
         ]
       }
@@ -34950,6 +36297,9 @@
         "name": "Team",
         "columns": [
           {
+            "name": "team_long_name"
+          },
+          {
             "name": "team_short_name"
           }
         ]
@@ -34992,6 +36342,9 @@
         "columns": [
           {
             "name": "height"
+          },
+          {
+            "name": "player_name"
           }
         ]
       }
@@ -35009,6 +36362,12 @@
       {
         "name": "Player_Attributes",
         "columns": [
+          {
+            "name": "attacking_work_rate"
+          },
+          {
+            "name": "player_api_id"
+          },
           {
             "name": "preferred_foot"
           }
@@ -35308,6 +36667,20 @@
             "name": "name"
           }
         ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "country_id"
+          },
+          {
+            "name": "id"
+          },
+          {
+            "name": "season"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(t2.id) FROM Country AS t1 INNER JOIN Match AS t2 ON t1.id = t2.country_id WHERE t1.name = 'Belgium' AND t2.season = '2008/2009'"
@@ -35363,6 +36736,17 @@
             "name": "name"
           }
         ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "id"
+          },
+          {
+            "name": "league_id"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(t2.id) FROM League AS t1 INNER JOIN Match AS t2 ON t1.id = t2.league_id WHERE t1.name = 'Belgium Jupiler League' AND SUBSTR(t2.\"date\", 1, 7) = '2009-04'"
@@ -35383,6 +36767,20 @@
           },
           {
             "name": "name"
+          }
+        ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "id"
+          },
+          {
+            "name": "league_id"
+          },
+          {
+            "name": "season"
           }
         ]
       }
@@ -35673,6 +37071,23 @@
     "SQL": "SELECT CAST(SUM(T1.away_team_goal) AS REAL) / COUNT(T1.id) FROM \"Match\" AS T1 INNER JOIN TEAM AS T2 ON T1.away_team_api_id = T2.team_api_id INNER JOIN Country AS T3 ON T1.country_id = T3.id WHERE T2.team_long_name = 'Parma' AND T3.name = 'Italy'",
     "difficulty": "moderate",
     "tables": [
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "away_team_api_id"
+          },
+          {
+            "name": "away_team_goal"
+          },
+          {
+            "name": "country_id"
+          },
+          {
+            "name": "id"
+          }
+        ]
+      },
       {
         "name": "TEAM",
         "columns": [
@@ -36205,6 +37620,9 @@
         "name": "Player",
         "columns": [
           {
+            "name": "player_api_id"
+          },
+          {
             "name": "weight"
           }
         ]
@@ -36222,7 +37640,14 @@
     "tables": [
       {
         "name": "Player",
-        "columns": []
+        "columns": [
+          {
+            "name": "birthday"
+          },
+          {
+            "name": "player_name"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT player_name FROM Player WHERE CAST((JULIANDAY('now') - JULIANDAY(birthday)) AS NUMBER) / 365 >= 35"
@@ -36243,6 +37668,17 @@
           },
           {
             "name": "player_name"
+          }
+        ]
+      },
+      {
+        "name": "match",
+        "columns": [
+          {
+            "name": "away_player_9"
+          },
+          {
+            "name": "home_team_goal"
           }
         ]
       }
@@ -36267,6 +37703,17 @@
             "name": "player_name"
           }
         ]
+      },
+      {
+        "name": "match",
+        "columns": [
+          {
+            "name": "away_player_5"
+          },
+          {
+            "name": "away_team_goal"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT SUM(t2.away_team_goal) FROM Player AS t1 INNER JOIN match AS t2 ON t1.player_api_id = t2.away_player_5 WHERE t1.player_name IN ('Daan Smith', 'Filipe Ferreira')"
@@ -36287,6 +37734,17 @@
           },
           {
             "name": "player_api_id"
+          }
+        ]
+      },
+      {
+        "name": "match",
+        "columns": [
+          {
+            "name": "away_player_1"
+          },
+          {
+            "name": "home_team_goal"
           }
         ]
       }
@@ -36448,6 +37906,17 @@
         ]
       },
       {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "country_id"
+          },
+          {
+            "name": "home_player_1"
+          }
+        ]
+      },
+      {
         "name": "Player",
         "columns": [
           {
@@ -36489,6 +37958,17 @@
         ]
       },
       {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "country_id"
+          },
+          {
+            "name": "home_player_8"
+          }
+        ]
+      },
+      {
         "name": "Country",
         "columns": [
           {
@@ -36518,6 +37998,17 @@
           },
           {
             "name": "name"
+          }
+        ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "country_id"
+          },
+          {
+            "name": "home_player_1"
           }
         ]
       },
@@ -36621,6 +38112,17 @@
         ]
       },
       {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "country_id"
+          },
+          {
+            "name": "id"
+          }
+        ]
+      },
+      {
         "name": "Country",
         "columns": [
           {
@@ -36669,6 +38171,12 @@
         "columns": [
           {
             "name": "birthday"
+          },
+          {
+            "name": "id"
+          },
+          {
+            "name": "player_name"
           }
         ]
       }
@@ -36708,6 +38216,9 @@
       {
         "name": "Player_Attributes",
         "columns": [
+          {
+            "name": "id"
+          },
           {
             "name": "potential"
           },
@@ -36754,7 +38265,17 @@
     "tables": [
       {
         "name": "Player_Attributes",
-        "columns": []
+        "columns": [
+          {
+            "name": "id"
+          },
+          {
+            "name": "stamina"
+          },
+          {
+            "name": "strength"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(COUNT(CASE WHEN strength > 80 AND stamina > 80 THEN id ELSE NULL END) AS NUMBER) * 100 / COUNT(id) FROM Player_Attributes t"
@@ -36801,6 +38322,20 @@
           },
           {
             "name": "name"
+          }
+        ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "away_team_goal"
+          },
+          {
+            "name": "home_team_goal"
+          },
+          {
+            "name": "league_id"
           }
         ]
       }
@@ -36884,6 +38419,20 @@
             "name": "name"
           }
         ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "id"
+          },
+          {
+            "name": "league_id"
+          },
+          {
+            "name": "season"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(t2.id) FROM League AS t1 INNER JOIN Match AS t2 ON t1.id = t2.league_id WHERE t1.name = 'Italy Serie A' AND t2.season = '2015/2016'"
@@ -36904,6 +38453,17 @@
           },
           {
             "name": "name"
+          }
+        ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "home_team_goal"
+          },
+          {
+            "name": "league_id"
           }
         ]
       }
@@ -36954,6 +38514,20 @@
             "name": "name"
           }
         ]
+      },
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "id"
+          },
+          {
+            "name": "league_id"
+          },
+          {
+            "name": "season"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT t1.name FROM League AS t1 INNER JOIN Match AS t2 ON t1.id = t2.league_id WHERE t2.season = '2015/2016' GROUP BY t1.name ORDER BY COUNT(t2.id) DESC FETCH FIRST 4 ROWS ONLY"
@@ -36966,6 +38540,17 @@
     "SQL": "SELECT t2.team_long_name FROM Match AS t1 INNER JOIN Team AS t2 ON t1.away_team_api_id = t2.team_api_id ORDER BY t1.away_team_goal DESC LIMIT 1",
     "difficulty": "moderate",
     "tables": [
+      {
+        "name": "Match",
+        "columns": [
+          {
+            "name": "away_team_api_id"
+          },
+          {
+            "name": "away_team_goal"
+          }
+        ]
+      },
       {
         "name": "Team",
         "columns": [
@@ -37061,6 +38646,9 @@
         "name": "Patient",
         "columns": [
           {
+            "name": "Admission"
+          },
+          {
             "name": "SEX"
           }
         ]
@@ -37080,6 +38668,9 @@
         "name": "Patient",
         "columns": [
           {
+            "name": "Birthday"
+          },
+          {
             "name": "SEX"
           }
         ]
@@ -37097,7 +38688,14 @@
     "tables": [
       {
         "name": "Patient",
-        "columns": []
+        "columns": [
+          {
+            "name": "Admission"
+          },
+          {
+            "name": "Birthday"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(SUM(CASE WHEN Admission = '+' THEN 1 ELSE 0 END) AS NUMBER) * 100 / COUNT(*) FROM Patient WHERE TO_CHAR(Birthday, 'YYYY') BETWEEN '1930' AND '1940'"
@@ -37113,6 +38711,9 @@
       {
         "name": "Patient",
         "columns": [
+          {
+            "name": "Admission"
+          },
           {
             "name": "Diagnosis"
           }
@@ -37449,7 +39050,17 @@
     "tables": [
       {
         "name": "Patient",
-        "columns": []
+        "columns": [
+          {
+            "name": "Admission"
+          },
+          {
+            "name": "Description"
+          },
+          {
+            "name": "SEX"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(*) FROM Patient WHERE TO_CHAR(Description, 'YYYY') = '1997' AND SEX = 'F' AND Admission = '-'"
@@ -37465,6 +39076,9 @@
       {
         "name": "Patient",
         "columns": [
+          {
+            "name": "Birthday"
+          },
           {
             "name": "First Date"
           }
@@ -37902,6 +39516,9 @@
         "name": "Examination",
         "columns": [
           {
+            "name": "ANA"
+          },
+          {
             "name": "Examination Date"
           },
           {
@@ -37924,7 +39541,13 @@
         "name": "Laboratory",
         "columns": [
           {
+            "name": "CHO"
+          },
+          {
             "name": "ID"
+          },
+          {
+            "name": "T"
           },
           {
             "name": "T-CHO"
@@ -37950,6 +39573,9 @@
           },
           {
             "name": "First Date"
+          },
+          {
+            "name": "SEX"
           }
         ]
       }
@@ -38209,7 +39835,13 @@
         "name": "Examination",
         "columns": [
           {
+            "name": "Diagnosis"
+          },
+          {
             "name": "Examination Date"
+          },
+          {
+            "name": "ID"
           }
         ]
       }
@@ -38226,7 +39858,17 @@
     "tables": [
       {
         "name": "Laboratory",
-        "columns": []
+        "columns": [
+          {
+            "name": "ALB"
+          },
+          {
+            "name": "GPT"
+          },
+          {
+            "name": "ID"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT DISTINCT ID FROM Laboratory WHERE Date BETWEEN '1987-07-06' AND '1996-01-31' AND GPT > 30 AND ALB < 4"
@@ -38241,7 +39883,20 @@
     "tables": [
       {
         "name": "Patient",
-        "columns": []
+        "columns": [
+          {
+            "name": "Admission"
+          },
+          {
+            "name": "Birthday"
+          },
+          {
+            "name": "ID"
+          },
+          {
+            "name": "SEX"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT ID FROM Patient WHERE TO_CHAR(Birthday, 'YYYY') = '1964' AND SEX = 'F' AND Admission = '+'"
@@ -38258,10 +39913,22 @@
         "name": "Examination",
         "columns": [
           {
+            "name": "ANA"
+          },
+          {
             "name": "ANA Pattern"
           },
           {
+            "name": "IgM"
+          },
+          {
+            "name": "Pattern"
+          },
+          {
             "name": "Thrombosis"
+          },
+          {
+            "name": "aCL"
           },
           {
             "name": "aCL IgM"
@@ -38283,7 +39950,19 @@
         "name": "Laboratory",
         "columns": [
           {
+            "name": "ID"
+          },
+          {
+            "name": "PRO"
+          },
+          {
+            "name": "U"
+          },
+          {
             "name": "U-PRO"
+          },
+          {
+            "name": "UA"
           }
         ]
       }
@@ -38302,7 +39981,16 @@
         "name": "Patient",
         "columns": [
           {
+            "name": "Diagnosis"
+          },
+          {
             "name": "First Date"
+          },
+          {
+            "name": "ID"
+          },
+          {
+            "name": "SEX"
           }
         ]
       }
@@ -38504,6 +40192,9 @@
         "name": "Patient",
         "columns": [
           {
+            "name": "Diagnosis"
+          },
+          {
             "name": "First Date"
           },
           {
@@ -38526,6 +40217,12 @@
         "name": "Patient",
         "columns": [
           {
+            "name": "Diagnosis"
+          },
+          {
+            "name": "ID"
+          },
+          {
             "name": "SEX"
           }
         ]
@@ -38543,7 +40240,14 @@
     "tables": [
       {
         "name": "Laboratory",
-        "columns": []
+        "columns": [
+          {
+            "name": "ALB"
+          },
+          {
+            "name": "ID"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT COUNT(ID) FROM Laboratory WHERE (ALB <= 6.0 OR ALB >= 8.5) AND TO_CHAR(Date, 'YYYY') = '1997'"
@@ -38559,6 +40263,12 @@
       {
         "name": "Examination",
         "columns": [
+          {
+            "name": "Diagnosis"
+          },
+          {
+            "name": "ID"
+          },
           {
             "name": "Symptoms"
           }
@@ -38579,7 +40289,16 @@
         "name": "Patient",
         "columns": [
           {
+            "name": "Birthday"
+          },
+          {
             "name": "Diagnosis"
+          },
+          {
+            "name": "ID"
+          },
+          {
+            "name": "SEX"
           }
         ]
       }
@@ -38741,6 +40460,9 @@
       {
         "name": "Laboratory",
         "columns": [
+          {
+            "name": "GOT"
+          },
           {
             "name": "ID"
           }
@@ -40344,9 +42066,6 @@
           },
           {
             "name": "ID"
-          },
-          {
-            "name": "labData"
           }
         ]
       },
@@ -42891,6 +44610,9 @@
         "columns": [
           {
             "name": "cost"
+          },
+          {
+            "name": "expense_description"
           }
         ]
       }
@@ -43463,6 +45185,9 @@
         "columns": [
           {
             "name": "event_name"
+          },
+          {
+            "name": "location"
           }
         ]
       }
@@ -43480,6 +45205,12 @@
       {
         "name": "expense",
         "columns": [
+          {
+            "name": "cost"
+          },
+          {
+            "name": "expense_date"
+          },
           {
             "name": "expense_description"
           }
@@ -43500,7 +45231,13 @@
         "name": "budget",
         "columns": [
           {
+            "name": "amount"
+          },
+          {
             "name": "category"
+          },
+          {
+            "name": "remaining"
           }
         ]
       }
@@ -43518,6 +45255,12 @@
       {
         "name": "income",
         "columns": [
+          {
+            "name": "date_received"
+          },
+          {
+            "name": "notes"
+          },
           {
             "name": "source"
           }
@@ -43539,6 +45282,9 @@
         "columns": [
           {
             "name": "college"
+          },
+          {
+            "name": "major_name"
           }
         ]
       }
@@ -43558,6 +45304,12 @@
         "columns": [
           {
             "name": "first_name"
+          },
+          {
+            "name": "last_name"
+          },
+          {
+            "name": "phone"
           }
         ]
       }
@@ -44077,6 +45829,9 @@
         "name": "expense",
         "columns": [
           {
+            "name": "cost"
+          },
+          {
             "name": "expense_description"
           }
         ]
@@ -44096,7 +45851,13 @@
         "name": "zip_code",
         "columns": [
           {
+            "name": "city"
+          },
+          {
             "name": "county"
+          },
+          {
+            "name": "state"
           }
         ]
       }
@@ -44116,6 +45877,9 @@
         "columns": [
           {
             "name": "college"
+          },
+          {
+            "name": "department"
           }
         ]
       }
@@ -44592,6 +46356,9 @@
         "name": "member",
         "columns": [
           {
+            "name": "member_id"
+          },
+          {
             "name": "position"
           }
         ]
@@ -44609,7 +46376,11 @@
     "tables": [
       {
         "name": "budget",
-        "columns": []
+        "columns": [
+          {
+            "name": "spent"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT MAX(spent) FROM budget"
@@ -44625,6 +46396,12 @@
       {
         "name": "event",
         "columns": [
+          {
+            "name": "event_date"
+          },
+          {
+            "name": "event_id"
+          },
           {
             "name": "type"
           }
@@ -44646,6 +46423,9 @@
         "columns": [
           {
             "name": "category"
+          },
+          {
+            "name": "spent"
           }
         ]
       }
@@ -45099,7 +46879,14 @@
     "tables": [
       {
         "name": "major",
-        "columns": []
+        "columns": [
+          {
+            "name": "major_name"
+          },
+          {
+            "name": "ratio"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT SUM(CASE WHEN major_name = 'Finance' THEN 1 ELSE 0 END) / SUM(CASE WHEN major_name = 'Physics' THEN 1 ELSE 0 END) AS ratio FROM major"
@@ -45137,6 +46924,15 @@
       {
         "name": "member",
         "columns": [
+          {
+            "name": "email"
+          },
+          {
+            "name": "first_name"
+          },
+          {
+            "name": "last_name"
+          },
           {
             "name": "position"
           }
@@ -45277,6 +47073,12 @@
         "columns": [
           {
             "name": "category"
+          },
+          {
+            "name": "event_status"
+          },
+          {
+            "name": "spent"
           }
         ]
       }
@@ -45376,7 +47178,14 @@
     "tables": [
       {
         "name": "event",
-        "columns": []
+        "columns": [
+          {
+            "name": "event_date"
+          },
+          {
+            "name": "type"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(SUM(CASE WHEN type = 'Community Service' THEN 1 ELSE 0 END) AS NUMBER) * 100 / COUNT(type) FROM event WHERE SUBSTR(event_date, 1, 4) = '2019'"
@@ -45578,6 +47387,12 @@
         "name": "budget",
         "columns": [
           {
+            "name": "amount"
+          },
+          {
+            "name": "budget_id"
+          },
+          {
             "name": "category"
           }
         ]
@@ -45600,6 +47415,9 @@
             "name": "amount"
           },
           {
+            "name": "budget_id"
+          },
+          {
             "name": "category"
           }
         ]
@@ -45619,6 +47437,9 @@
         "name": "expense",
         "columns": [
           {
+            "name": "cost"
+          },
+          {
             "name": "expense_description"
           }
         ]
@@ -45637,6 +47458,9 @@
       {
         "name": "expense",
         "columns": [
+          {
+            "name": "cost"
+          },
           {
             "name": "expense_date"
           }
@@ -46102,6 +47926,9 @@
         "columns": [
           {
             "name": "amount"
+          },
+          {
+            "name": "income_id"
           }
         ]
       }
@@ -46120,7 +47947,13 @@
         "name": "member",
         "columns": [
           {
+            "name": "member_id"
+          },
+          {
             "name": "position"
+          },
+          {
+            "name": "t_shirt_size"
           }
         ]
       }
@@ -46139,7 +47972,13 @@
         "name": "major",
         "columns": [
           {
+            "name": "college"
+          },
+          {
             "name": "department"
+          },
+          {
+            "name": "major_id"
           }
         ]
       }
@@ -46455,6 +48294,9 @@
         "name": "zip_code",
         "columns": [
           {
+            "name": "county"
+          },
+          {
             "name": "type"
           }
         ]
@@ -46474,6 +48316,12 @@
         "name": "zip_code",
         "columns": [
           {
+            "name": "county"
+          },
+          {
+            "name": "state"
+          },
+          {
             "name": "type"
           }
         ]
@@ -46492,6 +48340,15 @@
       {
         "name": "event",
         "columns": [
+          {
+            "name": "event_date"
+          },
+          {
+            "name": "event_name"
+          },
+          {
+            "name": "status"
+          },
           {
             "name": "type"
           }
@@ -46739,7 +48596,14 @@
     "tables": [
       {
         "name": "budget",
-        "columns": []
+        "columns": [
+          {
+            "name": "budget_id"
+          },
+          {
+            "name": "remaining"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(SUM(CASE WHEN remaining < 0 THEN 1 ELSE 0 END) AS NUMBER) * 100 / COUNT(budget_id) FROM budget"
@@ -46754,7 +48618,20 @@
     "tables": [
       {
         "name": "event",
-        "columns": []
+        "columns": [
+          {
+            "name": "event_date"
+          },
+          {
+            "name": "event_id"
+          },
+          {
+            "name": "location"
+          },
+          {
+            "name": "status"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT event_id, location, status FROM event WHERE date(SUBSTR(event_date, 1, 10)) BETWEEN '2019-11-01' AND '2020-03-31'"
@@ -46770,6 +48647,9 @@
       {
         "name": "expense",
         "columns": [
+          {
+            "name": "cost"
+          },
           {
             "name": "expense_description"
           }
@@ -46790,6 +48670,12 @@
         "name": "member",
         "columns": [
           {
+            "name": "first_name"
+          },
+          {
+            "name": "last_name"
+          },
+          {
             "name": "t_shirt_size"
           }
         ]
@@ -46807,7 +48693,11 @@
     "tables": [
       {
         "name": "zip_code",
-        "columns": []
+        "columns": [
+          {
+            "name": "type"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(SUM(CASE WHEN type = 'PO Box' THEN 1 ELSE 0 END) AS NUMBER) * 100 / COUNT(zip_code) FROM zip_code"
@@ -47771,6 +49661,12 @@
         "columns": [
           {
             "name": "Country"
+          },
+          {
+            "name": "GasStationID"
+          },
+          {
+            "name": "Segment"
           }
         ]
       }
@@ -47787,7 +49683,14 @@
     "tables": [
       {
         "name": "customers",
-        "columns": []
+        "columns": [
+          {
+            "name": "Currency"
+          },
+          {
+            "name": "ratio"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(SUM(CASE WHEN Currency = 'EUR' THEN 1 ELSE 0 END) AS NUMBER) / SUM(CASE WHEN Currency = 'CZK' THEN 1 ELSE 0 END) AS ratio FROM customers"
@@ -48173,6 +50076,9 @@
         "name": "yearmonth",
         "columns": [
           {
+            "name": "Consumption"
+          },
+          {
             "name": "CustomerID"
           }
         ]
@@ -48192,6 +50098,9 @@
         "name": "gasstations",
         "columns": [
           {
+            "name": "Country"
+          },
+          {
             "name": "Segment"
           }
         ]
@@ -48209,7 +50118,14 @@
     "tables": [
       {
         "name": "yearmonth",
-        "columns": []
+        "columns": [
+          {
+            "name": "Consumption"
+          },
+          {
+            "name": "CustomerID"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT SUM(CASE WHEN CustomerID = 7 THEN Consumption ELSE 0 END) - SUM(CASE WHEN CustomerID = 5 THEN Consumption ELSE 0 END) FROM yearmonth WHERE Date = '201304'"
@@ -48225,6 +50141,9 @@
       {
         "name": "customers",
         "columns": [
+          {
+            "name": "Currency"
+          },
           {
             "name": "Segment"
           }
@@ -48383,6 +50302,9 @@
             "name": "Country"
           },
           {
+            "name": "GasStationID"
+          },
+          {
             "name": "Segment"
           }
         ]
@@ -48402,6 +50324,12 @@
         "name": "customers",
         "columns": [
           {
+            "name": "Currency"
+          },
+          {
+            "name": "CustomerID"
+          },
+          {
             "name": "Segment"
           }
         ]
@@ -48419,7 +50347,14 @@
     "tables": [
       {
         "name": "yearmonth",
-        "columns": []
+        "columns": [
+          {
+            "name": "Consumption"
+          },
+          {
+            "name": "CustomerID"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(SUM(CASE WHEN Consumption > 528.3 THEN 1 ELSE 0 END) AS NUMBER) * 100 / COUNT(CustomerID) FROM yearmonth WHERE Date = '201202'"
@@ -48437,6 +50372,12 @@
         "columns": [
           {
             "name": "Country"
+          },
+          {
+            "name": "GasStationID"
+          },
+          {
+            "name": "Segment"
           }
         ]
       }
@@ -48549,7 +50490,11 @@
     "tables": [
       {
         "name": "yearmonth",
-        "columns": []
+        "columns": [
+          {
+            "name": "Consumption"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT SUM(Consumption) FROM yearmonth WHERE SUBSTR(Date, 1, 4) = '2012' GROUP BY SUBSTR(Date, 5, 2) ORDER BY SUM(Consumption) DESC FETCH FIRST 1 ROWS ONLY"
@@ -48770,7 +50715,11 @@
     "tables": [
       {
         "name": "transactions_1k",
-        "columns": []
+        "columns": [
+          {
+            "name": "Amount"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT AVG(Amount) FROM transactions_1k WHERE Date LIKE '2012-01%'"
@@ -49041,6 +50990,9 @@
         "columns": [
           {
             "name": "CustomerID"
+          },
+          {
+            "name": "Price"
           }
         ]
       }
@@ -49516,6 +51468,9 @@
         "columns": [
           {
             "name": "GasStationID"
+          },
+          {
+            "name": "Price"
           }
         ]
       }
@@ -49532,7 +51487,14 @@
     "tables": [
       {
         "name": "gasstations",
-        "columns": []
+        "columns": [
+          {
+            "name": "Country"
+          },
+          {
+            "name": "Segment"
+          }
+        ]
       }
     ],
     "oracle_SQL": "SELECT CAST(SUM(CASE WHEN Country = 'SVK' AND Segment = 'Premium' THEN 1 ELSE 0 END) AS NUMBER) * 100 / SUM(CASE WHEN Country = 'SVK' THEN 1 ELSE 0 END) FROM gasstations"

--- a/dev_with_metadata.json
+++ b/dev_with_metadata.json
@@ -5828,6 +5828,17 @@
     "difficulty": "simple",
     "tables": [
       {
+        "name": "order",
+        "columns": [
+          {
+            "name": "account_id"
+          },
+          {
+            "name": "order_id"
+          }
+        ]
+      },
+      {
         "name": "account",
         "columns": [
           {
@@ -5835,9 +5846,6 @@
           },
           {
             "name": "district_id"
-          },
-          {
-            "name": "order_id"
           }
         ]
       },
@@ -5848,10 +5856,6 @@
             "name": "district_id"
           }
         ]
-      },
-      {
-        "name": "",
-        "columns": []
       }
     ],
     "oracle_SQL": "SELECT T3.district_id FROM \"order\" AS T1 INNER JOIN account AS T2 ON T1.account_id = T2.account_id INNER JOIN district AS T3 ON T2.district_id = T3.district_id WHERE T1.order_id = 33333"
@@ -6068,13 +6072,21 @@
     "difficulty": "simple",
     "tables": [
       {
-        "name": "account",
+        "name": "order",
         "columns": [
           {
             "name": "account_id"
           },
           {
             "name": "order_id"
+          }
+        ]
+      },
+      {
+        "name": "account",
+        "columns": [
+          {
+            "name": "account_id"
           }
         ]
       },
@@ -6096,10 +6108,6 @@
             "name": "client_id"
           }
         ]
-      },
-      {
-        "name": "",
-        "columns": []
       }
     ],
     "oracle_SQL": "SELECT T3.client_id FROM \"order\" AS T1 INNER JOIN account AS T2 ON T1.account_id = T2.account_id INNER JOIN disp AS T4 ON T4.account_id = T2.account_id  INNER JOIN client AS T3 ON T4.client_id = T3.client_id WHERE T1.order_id = 32423"
@@ -6386,18 +6394,13 @@
             "name": "account_id"
           },
           {
-            "name": "amount"
-          },
-          {
             "name": "frequency"
-          },
-          {
-            "name": "k_symbol"
-          },
-          {
-            "name": "total_amount"
           }
         ]
+      },
+      {
+        "name": "order",
+        "columns": []
       }
     ],
     "oracle_SQL": "SELECT T1.frequency, T2.k_symbol FROM account AS T1 INNER JOIN (SELECT account_id, k_symbol, SUM(amount) AS total_amount FROM \"order\" GROUP BY account_id, k_symbol) AS T2 ON T1.account_id = T2.account_id WHERE T1.account_id = 3 AND T2.total_amount = 3539"
@@ -7350,9 +7353,6 @@
         "name": "bond",
         "columns": [
           {
-            "name": "T"
-          },
-          {
             "name": "bond_id"
           },
           {
@@ -8214,12 +8214,6 @@
         "name": "bond",
         "columns": [
           {
-            "name": "atom_id1"
-          },
-          {
-            "name": "atom_id2"
-          },
-          {
             "name": "bond_id"
           },
           {
@@ -8241,9 +8235,6 @@
       {
         "name": "molecule",
         "columns": [
-          {
-            "name": "diff_car_notcar"
-          },
           {
             "name": "label"
           },
@@ -8459,9 +8450,6 @@
       {
         "name": "bond",
         "columns": [
-          {
-            "name": "T"
-          },
           {
             "name": "bond_type"
           },
@@ -26191,9 +26179,6 @@
       {
         "name": "superhero",
         "columns": [
-          {
-            "name": "CALCULATE"
-          },
           {
             "name": "full_name"
           },
@@ -46801,9 +46786,6 @@
         "columns": [
           {
             "name": "major_name"
-          },
-          {
-            "name": "ratio"
           }
         ]
       }
@@ -49605,9 +49587,6 @@
         "columns": [
           {
             "name": "Currency"
-          },
-          {
-            "name": "ratio"
           }
         ]
       }


### PR DESCRIPTION
### Motivation

- Enable using Groq-hosted inference and support batched LLM requests for OpenAI-compatible backends so many questions (e.g., 30–40) can be sent in a single request. 
- Keep existing Ollama path for local models and preserve OpenRouter-specific header handling.

### Description

- Added `groq` to `--llm-provider` choices and added a new CLI flag `--llm-batch-size` to control how many questions are sent per request. 
- Implemented `extract_tables_with_columns_llm_openai_compat_batch(...)` which posts a single `POST /chat/completions` style request (JSON payload with `messages`) to OpenAI-compatible endpoints and maps results back by index. 
- Updated `process_dev_file(...)` to run OpenAI-compatible providers (`openai_compat`, `openrouter`, `groq`) in batches using the new batch extractor and to fall back per-item to the `rule_based` extractor when batch output is missing/invalid, while keeping Ollama per-item behavior. 
- Kept OpenRouter defaults and optional headers (`HTTP-Referer` / `X-Title`) and added Groq defaults/env lookup (`GROQ_API_KEY`, default base URL `https://api.groq.com/openai/v1`). 
- Updated `README.md` with `groq` usage, OpenRouter notes, and batching instructions/examples.

### Testing

- Ran syntax check with `python -m py_compile add_dev_questions_metadata.py`, which succeeded. 
- Verified CLI help with `python add_dev_questions_metadata.py --help`, which shows updated options and new `--llm-batch-size`. 
- Ran the script in `rule_based` mode on a small sample (`python add_dev_questions_metadata.py /tmp/dev_sample.json /tmp/dev_sample_out.json --method rule_based`) and observed successful completion and statistics output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69940eb436bc8322955166be7a608fbe)