### PR TITLE
Add hybrid `search_type` (vector|hybrid), NLTK auto-keyword extraction, PL/SQL hybrid params, and docs

### DIFF
--- a/HYBRID_SEARCH_EVALUATION.md
+++ b/HYBRID_SEARCH_EVALUATION.md
@@ -181,6 +181,7 @@ Then open `http://localhost:8000/report.html` in your browser.
 | `--single-user-mode` | | false | Load all selected schemas into one Oracle user and run all queries there |
 | `--single-user-name` | | `BIRD_ALL` | Username for `--single-user-mode` (password is the same as username) |
 | `--mode` | sequential\|parallel\|unified | sequential | Select discovery procedure (`discover_objects`, `discover_objects_parallel`, or `discover_objects_unified`) |
+| `--search-type` | vector\|hybrid | vector | Request shape sent to package. `vector` keeps legacy args; `hybrid` sends vector+keyword args |
 
 ### Discovery Argument Group
 
@@ -196,6 +197,20 @@ You can now provide discovery procedure arguments as a grouped JSON config and/o
 | `--discover-cols-per-obj` | 5 | Max columns attached per object |
 | `--discover-alpha` | 0.65 | Sequential rerank blend alpha (`p_alpha`) |
 | `--discover-parallel-alpha` | 0.60 | Parallel rerank blend alpha (`p_alpha`) |
+| `--discover-unified-score-threshold` | 0.60 | Unified mode score threshold |
+| `--discover-search-scorer` | RSF | Hybrid `search_scorer` |
+| `--discover-search-fusion` | UNION | Hybrid `search_fusion` |
+| `--discover-vector-search-mode` | DOCUMENT | Hybrid `vector.search_mode` |
+| `--discover-vector-aggregator` | MAX | Hybrid `vector.aggregator` |
+| `--discover-vector-score-weight` | 1 | Hybrid `vector.score_weight` |
+| `--discover-vector-rank-penalty` | 5 | Hybrid `vector.rank_penalty` |
+| `--discover-text-contains` | auto | Hybrid `text.contains` override |
+| `--discover-text-score-weight` | 10 | Hybrid `text.score_weight` |
+| `--discover-text-rank-penalty` | 1 | Hybrid `text.rank_penalty` |
+
+`--discover-text-contains` auto behavior: when `--search-type hybrid` is used and this
+flag is omitted, the runner generates keywords from the query text via Python NLTK
+(`word_tokenize`, English stopwords filtering, `isalpha`, dedupe, joined with `OR`).
 
 Override precedence: explicit CLI flags > `--discover-config-json` > built-in defaults.
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,16 @@ Optional dependencies:
 
 ## Hybrid Search Evaluation
 
-Use `run_hybrid_search_evaluation.py` for Oracle hybrid discovery benchmarking with sequential or parallel discovery modes.
+Use `run_hybrid_search_evaluation.py` for Oracle metadata discovery benchmarking with sequential, parallel, or unified modes.
+
+The runner now supports two request styles:
+
+- `--search-type vector` (default): sends legacy vector-style procedure arguments
+- `--search-type hybrid`: sends hybrid vector+keyword arguments (scorer/fusion/vector/text knobs)
+
+When running with `--search-type hybrid`, if `--discover-text-contains` is not provided,
+the runner auto-generates `text.contains` keywords from the NL query in Python using NLTK
+tokenization + stopword filtering and joins terms with `OR`.
 
 Example with parallel mode and grouped discovery config:
 
@@ -311,7 +320,20 @@ Example with parallel mode and grouped discovery config:
 python run_hybrid_search_evaluation.py \
   --connection-string "sys/password@localhost:1521/FREEPDB1" \
   --mode parallel \
+  --search-type hybrid \
   --discover-config-json '{"k":10,"m":80,"cols_per_obj":5,"parallel_alpha":0.60}'
 ```
+
+Optional hybrid tuning flags:
+
+- `--discover-search-scorer`
+- `--discover-search-fusion`
+- `--discover-vector-search-mode`
+- `--discover-vector-aggregator`
+- `--discover-vector-score-weight`
+- `--discover-vector-rank-penalty`
+- `--discover-text-contains`
+- `--discover-text-score-weight`
+- `--discover-text-rank-penalty`
 
 The generated HTML/CSV reports include additional @K metrics (Recall, Precision, F1) for both table and column evaluation.

--- a/index_creation.sql
+++ b/index_creation.sql
@@ -213,6 +213,15 @@ CREATE OR REPLACE PACKAGE developer AUTHID CURRENT_USER AS
     p_n             IN  PLS_INTEGER DEFAULT NULL,
     p_cols_per_obj  IN  PLS_INTEGER DEFAULT 3,
     p_alpha         IN  NUMBER      DEFAULT 0.65,
+    p_search_scorer IN  VARCHAR2    DEFAULT 'RSF',
+    p_search_fusion IN  VARCHAR2    DEFAULT 'UNION',
+    p_vector_search_mode  IN VARCHAR2 DEFAULT 'DOCUMENT',
+    p_vector_aggregator   IN VARCHAR2 DEFAULT 'MAX',
+    p_vector_score_weight IN NUMBER   DEFAULT 1,
+    p_vector_rank_penalty IN NUMBER   DEFAULT 5,
+    p_text_contains       IN CLOB     DEFAULT NULL,
+    p_text_score_weight   IN NUMBER   DEFAULT 10,
+    p_text_rank_penalty   IN NUMBER   DEFAULT 1,
     p_result_json   OUT JSON
   );
 
@@ -242,6 +251,15 @@ CREATE OR REPLACE PACKAGE developer AUTHID CURRENT_USER AS
     p_m             IN  PLS_INTEGER DEFAULT NULL,
     p_cols_per_obj  IN  PLS_INTEGER DEFAULT 3,
     p_alpha         IN  NUMBER      DEFAULT 0.60,
+    p_search_scorer IN  VARCHAR2    DEFAULT 'RSF',
+    p_search_fusion IN  VARCHAR2    DEFAULT 'UNION',
+    p_vector_search_mode  IN VARCHAR2 DEFAULT 'DOCUMENT',
+    p_vector_aggregator   IN VARCHAR2 DEFAULT 'MAX',
+    p_vector_score_weight IN NUMBER   DEFAULT 1,
+    p_vector_rank_penalty IN NUMBER   DEFAULT 5,
+    p_text_contains       IN CLOB     DEFAULT NULL,
+    p_text_score_weight   IN NUMBER   DEFAULT 10,
+    p_text_rank_penalty   IN NUMBER   DEFAULT 1,
     p_result_json   OUT JSON
   );
 
@@ -272,6 +290,15 @@ CREATE OR REPLACE PACKAGE developer AUTHID CURRENT_USER AS
     p_m                IN  PLS_INTEGER DEFAULT 10,
     p_cols_per_obj     IN  PLS_INTEGER DEFAULT 10,
     p_score_threshold  IN  NUMBER      DEFAULT 0.6,
+    p_search_scorer IN  VARCHAR2    DEFAULT 'RSF',
+    p_search_fusion IN  VARCHAR2    DEFAULT 'UNION',
+    p_vector_search_mode  IN VARCHAR2 DEFAULT 'DOCUMENT',
+    p_vector_aggregator   IN VARCHAR2 DEFAULT 'MAX',
+    p_vector_score_weight IN NUMBER   DEFAULT 1,
+    p_vector_rank_penalty IN NUMBER   DEFAULT 5,
+    p_text_contains       IN CLOB     DEFAULT NULL,
+    p_text_score_weight   IN NUMBER   DEFAULT 10,
+    p_text_rank_penalty   IN NUMBER   DEFAULT 1,
     p_result_json      OUT JSON
   );
 
@@ -279,6 +306,42 @@ END developer;
 /
 
 CREATE OR REPLACE PACKAGE BODY developer AS
+
+  PROCEDURE apply_hybrid_search_params(
+    p_req IN OUT NOCOPY JSON_OBJECT_T,
+    p_query IN CLOB,
+    p_search_scorer IN VARCHAR2,
+    p_search_fusion IN VARCHAR2,
+    p_vector_search_mode IN VARCHAR2,
+    p_vector_aggregator IN VARCHAR2,
+    p_vector_score_weight IN NUMBER,
+    p_vector_rank_penalty IN NUMBER,
+    p_text_contains IN CLOB,
+    p_text_score_weight IN NUMBER,
+    p_text_rank_penalty IN NUMBER
+  ) IS
+    l_vector JSON_OBJECT_T := JSON_OBJECT_T();
+    l_text JSON_OBJECT_T := JSON_OBJECT_T();
+    l_contains CLOB;
+  BEGIN
+    p_req.put('search_scorer', UPPER(NVL(p_search_scorer, 'RSF')));
+    p_req.put('search_fusion', UPPER(NVL(p_search_fusion, 'UNION')));
+
+    l_vector.put('search_text', p_query);
+    l_vector.put('search_mode', UPPER(NVL(p_vector_search_mode, 'DOCUMENT')));
+    l_vector.put('aggregator', UPPER(NVL(p_vector_aggregator, 'MAX')));
+    l_vector.put('score_weight', NVL(p_vector_score_weight, 1));
+    l_vector.put('rank_penalty', NVL(p_vector_rank_penalty, 5));
+    p_req.put('vector', l_vector);
+
+    l_contains := p_text_contains;
+    IF l_contains IS NOT NULL THEN
+      l_text.put('contains', l_contains);
+    END IF;
+    l_text.put('score_weight', NVL(p_text_score_weight, 10));
+    l_text.put('rank_penalty', NVL(p_text_rank_penalty, 1));
+    p_req.put('text', l_text);
+  END apply_hybrid_search_params;
 
   /* ------------------------------------------------------------------------ */
   /* Utility: best-effort drop helper (ignore not-exists)                      */
@@ -617,6 +680,15 @@ CREATE OR REPLACE PACKAGE BODY developer AS
     p_n             IN  PLS_INTEGER DEFAULT NULL,
     p_cols_per_obj  IN  PLS_INTEGER DEFAULT 3,
     p_alpha         IN  NUMBER      DEFAULT 0.65,
+    p_search_scorer IN  VARCHAR2    DEFAULT 'RSF',
+    p_search_fusion IN  VARCHAR2    DEFAULT 'UNION',
+    p_vector_search_mode  IN VARCHAR2 DEFAULT 'DOCUMENT',
+    p_vector_aggregator   IN VARCHAR2 DEFAULT 'MAX',
+    p_vector_score_weight IN NUMBER   DEFAULT 1,
+    p_vector_rank_penalty IN NUMBER   DEFAULT 5,
+    p_text_contains       IN CLOB     DEFAULT NULL,
+    p_text_score_weight   IN NUMBER   DEFAULT 10,
+    p_text_rank_penalty   IN NUMBER   DEFAULT 1,
     p_result_json   OUT JSON
   ) IS
     c_obj_index CONSTANT VARCHAR2(128) := 'OBJ_DISCOVERY_HVIX';
@@ -687,7 +759,12 @@ CREATE OR REPLACE PACKAGE BODY developer AS
       ret.put('values', vals);
 
       req.put('hybrid_index_name', c_obj_index);
-      req.put('search_text', p_query);
+      apply_hybrid_search_params(
+        req, p_query, p_search_scorer, p_search_fusion,
+        p_vector_search_mode, p_vector_aggregator,
+        p_vector_score_weight, p_vector_rank_penalty,
+        p_text_contains, p_text_score_weight, p_text_rank_penalty
+      );
       req.put('return', ret);
 
       l_obj_res := DBMS_HYBRID_VECTOR.SEARCH(req.to_json);
@@ -755,7 +832,12 @@ CREATE OR REPLACE PACKAGE BODY developer AS
       ret.put('values', vals);
 
       req.put('hybrid_index_name', c_col_index);
-      req.put('search_text', p_query);
+      apply_hybrid_search_params(
+        req, p_query, p_search_scorer, p_search_fusion,
+        p_vector_search_mode, p_vector_aggregator,
+        p_vector_score_weight, p_vector_rank_penalty,
+        p_text_contains, p_text_score_weight, p_text_rank_penalty
+      );
       req.put('filter_by', fb);
       req.put('return', ret);
 
@@ -913,6 +995,15 @@ CREATE OR REPLACE PACKAGE BODY developer AS
     p_m             IN  PLS_INTEGER DEFAULT NULL,
     p_cols_per_obj  IN  PLS_INTEGER DEFAULT 3,
     p_alpha         IN  NUMBER      DEFAULT 0.60,
+    p_search_scorer IN  VARCHAR2    DEFAULT 'RSF',
+    p_search_fusion IN  VARCHAR2    DEFAULT 'UNION',
+    p_vector_search_mode  IN VARCHAR2 DEFAULT 'DOCUMENT',
+    p_vector_aggregator   IN VARCHAR2 DEFAULT 'MAX',
+    p_vector_score_weight IN NUMBER   DEFAULT 1,
+    p_vector_rank_penalty IN NUMBER   DEFAULT 5,
+    p_text_contains       IN CLOB     DEFAULT NULL,
+    p_text_score_weight   IN NUMBER   DEFAULT 10,
+    p_text_rank_penalty   IN NUMBER   DEFAULT 1,
     p_result_json   OUT JSON
   ) IS
     c_obj_index CONSTANT VARCHAR2(128) := 'OBJ_DISCOVERY_HVIX';
@@ -987,7 +1078,12 @@ CREATE OR REPLACE PACKAGE BODY developer AS
       ret_obj.put('values', return_vals); 
       ret_obj.put('topN', l_k);
       req.put('hybrid_index_name', c_obj_index);
-      req.put('search_text', p_query);
+      apply_hybrid_search_params(
+        req, p_query, p_search_scorer, p_search_fusion,
+        p_vector_search_mode, p_vector_aggregator,
+        p_vector_score_weight, p_vector_rank_penalty,
+        p_text_contains, p_text_score_weight, p_text_rank_penalty
+      );
       req.put('return', ret_obj);
       l_obj_res := DBMS_HYBRID_VECTOR.SEARCH(req.to_json);
     END;
@@ -1035,7 +1131,12 @@ CREATE OR REPLACE PACKAGE BODY developer AS
       ret_obj.put('values', return_vals); 
       ret_obj.put('topN', l_m);
       req.put('hybrid_index_name', c_col_index);
-      req.put('search_text', p_query);
+      apply_hybrid_search_params(
+        req, p_query, p_search_scorer, p_search_fusion,
+        p_vector_search_mode, p_vector_aggregator,
+        p_vector_score_weight, p_vector_rank_penalty,
+        p_text_contains, p_text_score_weight, p_text_rank_penalty
+      );
       req.put('return', ret_obj);
       l_col_res := DBMS_HYBRID_VECTOR.SEARCH(req.to_json);
     END;
@@ -1211,6 +1312,15 @@ CREATE OR REPLACE PACKAGE BODY developer AS
     p_m                IN  PLS_INTEGER DEFAULT 10,
     p_cols_per_obj     IN  PLS_INTEGER DEFAULT 10,
     p_score_threshold  IN  NUMBER      DEFAULT 0.6,
+    p_search_scorer IN  VARCHAR2    DEFAULT 'RSF',
+    p_search_fusion IN  VARCHAR2    DEFAULT 'UNION',
+    p_vector_search_mode  IN VARCHAR2 DEFAULT 'DOCUMENT',
+    p_vector_aggregator   IN VARCHAR2 DEFAULT 'MAX',
+    p_vector_score_weight IN NUMBER   DEFAULT 1,
+    p_vector_rank_penalty IN NUMBER   DEFAULT 5,
+    p_text_contains       IN CLOB     DEFAULT NULL,
+    p_text_score_weight   IN NUMBER   DEFAULT 10,
+    p_text_rank_penalty   IN NUMBER   DEFAULT 1,
     p_result_json      OUT JSON
   ) IS
     c_uni_index CONSTANT VARCHAR2(128) := 'UNI_DISCOVERY_HVIX';
@@ -1282,7 +1392,12 @@ CREATE OR REPLACE PACKAGE BODY developer AS
       ret.put('values', vals);
 
       req.put('hybrid_index_name', c_uni_index);
-      req.put('search_text', p_query);
+      apply_hybrid_search_params(
+        req, p_query, p_search_scorer, p_search_fusion,
+        p_vector_search_mode, p_vector_aggregator,
+        p_vector_score_weight, p_vector_rank_penalty,
+        p_text_contains, p_text_score_weight, p_text_rank_penalty
+      );
       req.put('return', ret);
 
       l_res := DBMS_HYBRID_VECTOR.SEARCH(req.to_json);

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ oracledb>=2.0.0
 
 # CSV processing (built-in, but listed for reference)
 # csv - standard library
+
+# Keyword extraction for hybrid text.contains auto-generation
+nltk>=3.8

--- a/run_hybrid_search_evaluation.py
+++ b/run_hybrid_search_evaluation.py
@@ -41,6 +41,15 @@ from typing import List, Dict, Optional, Set, Tuple
 from datetime import datetime
 
 try:
+    import nltk
+    from nltk.corpus import stopwords
+    from nltk.tokenize import word_tokenize
+except Exception:
+    nltk = None
+    stopwords = None
+    word_tokenize = None
+
+try:
     import oracledb
 except ImportError:
     print("Error: python-oracledb is required. Install with: pip install oracledb")
@@ -107,6 +116,20 @@ class DiscoveryConfig:
     alpha: float = 0.65
     parallel_alpha: float = 0.60
     unified_score_threshold: float = 0.60
+
+    # Search behavior
+    search_type: str = 'vector'  # vector | hybrid
+
+    # Hybrid-only knobs (defaults mirror index_creation.sql)
+    search_scorer: str = 'RSF'
+    search_fusion: str = 'UNION'
+    vector_search_mode: str = 'DOCUMENT'
+    vector_aggregator: str = 'MAX'
+    vector_score_weight: float = 1.0
+    vector_rank_penalty: float = 5.0
+    text_contains: Optional[str] = None
+    text_score_weight: float = 10.0
+    text_rank_penalty: float = 1.0
 
 
 @dataclass
@@ -252,6 +275,61 @@ class DatabaseSummary:
 # ============================================================================
 # Oracle Database Operations
 # ============================================================================
+
+_NLTK_READY = False
+
+def build_text_contains_from_query(text: str) -> Optional[str]:
+    """Build Oracle CONTAINS clause text using NLTK keyword extraction."""
+    global _NLTK_READY
+
+    if not text:
+        return None
+
+    # Preferred path: NLTK tokenization + English stop words
+    if nltk is not None and stopwords is not None and word_tokenize is not None:
+        try:
+            if not _NLTK_READY:
+                nltk.download('punkt', quiet=True)
+                nltk.download('stopwords', quiet=True)
+                nltk.download('punkt_tab', quiet=True)
+                _NLTK_READY = True
+
+            tokens = word_tokenize(text)
+            stop_words = set(stopwords.words('english'))
+            keywords = [w.lower() for w in tokens if w.isalpha() and w.lower() not in stop_words]
+
+            # preserve appearance order while deduplicating
+            seen = set()
+            ordered = []
+            for k in keywords:
+                if k not in seen:
+                    seen.add(k)
+                    ordered.append(k.upper())
+
+            return ' OR '.join(ordered) if ordered else None
+        except Exception:
+            pass
+
+    # Fallback when NLTK/resources are unavailable
+    fallback_stop = {
+        'a','an','the','and','or','but','if','then','else','when','at','by','for','with','about','against','between',
+        'into','through','during','before','after','above','below','to','from','up','down','in','out','on','off','over',
+        'under','again','further','than','once','here','there','all','any','both','each','few','more','most','other',
+        'some','such','no','nor','not','only','own','same','so','too','very','can','will','just','should','now','of',
+        'is','are','was','were','be','been','being','have','has','had','do','does','did','as','it','its','their','them',
+        'they','this','that','these','those','what','which','who','whom','why','how','please','list'
+    }
+    words = re.findall(r'[A-Za-z]+', text)
+    seen = set()
+    ordered = []
+    for w in words:
+        wl = w.lower()
+        if wl in fallback_stop:
+            continue
+        if wl not in seen:
+            seen.add(wl)
+            ordered.append(wl.upper())
+    return ' OR '.join(ordered) if ordered else None
 
 class OracleManager:
     """Manages Oracle database connections and operations."""
@@ -722,7 +800,13 @@ class OracleManager:
                          hints: Optional[str] = None, n: Optional[int] = None,
                          m: Optional[int] = None, alpha: float = 0.65,
                          parallel_alpha: float = 0.60,
-                         unified_score_threshold: float = 0.60) -> Tuple[Optional[List[DiscoveredObject]], float]:
+                         unified_score_threshold: float = 0.60,
+                         search_type: str = 'vector',
+                         search_scorer: str = 'RSF', search_fusion: str = 'UNION',
+                         vector_search_mode: str = 'DOCUMENT', vector_aggregator: str = 'MAX',
+                         vector_score_weight: float = 1.0, vector_rank_penalty: float = 5.0,
+                         text_contains: Optional[str] = None,
+                         text_score_weight: float = 10.0, text_rank_penalty: float = 1.0) -> Tuple[Optional[List[DiscoveredObject]], float]:
         """
         Call developer.discover_objects() and return results.
 
@@ -754,35 +838,79 @@ class OracleManager:
             start_time = time.perf_counter()
 
             # Call the procedure
+            use_hybrid = (search_type or 'vector').lower() == 'hybrid'
+            effective_text_contains = text_contains
+            if use_hybrid and not effective_text_contains:
+                effective_text_contains = build_text_contains_from_query(query)
+
             if discovery_mode == 'parallel':
-                cursor.callproc('developer.discover_objects_parallel', [
+                proc_args = [
                     query,          # p_query
                     hints,          # p_hints
                     k,              # p_k
                     m,              # p_m
                     cols_per_obj,   # p_cols_per_obj
                     parallel_alpha, # p_alpha
-                    result_json     # p_result_json (OUT)
-                ])
+                ]
+                if use_hybrid:
+                    proc_args.extend([
+                        search_scorer,
+                        search_fusion,
+                        vector_search_mode,
+                        vector_aggregator,
+                        vector_score_weight,
+                        vector_rank_penalty,
+                        effective_text_contains,
+                        text_score_weight,
+                        text_rank_penalty,
+                    ])
+                proc_args.append(result_json)  # p_result_json (OUT)
+                cursor.callproc('developer.discover_objects_parallel', proc_args)
             elif discovery_mode == 'unified':
-                cursor.callproc('developer.discover_objects_unified', [
+                proc_args = [
                     query,                   # p_query
                     k,                       # p_k
                     n,                       # p_n
                     cols_per_obj,            # p_cols_per_obj
                     unified_score_threshold, # p_score_threshold
-                    result_json              # p_result_json (OUT)
-                ])
+                ]
+                if use_hybrid:
+                    proc_args.extend([
+                        search_scorer,
+                        search_fusion,
+                        vector_search_mode,
+                        vector_aggregator,
+                        vector_score_weight,
+                        vector_rank_penalty,
+                        effective_text_contains,
+                        text_score_weight,
+                        text_rank_penalty,
+                    ])
+                proc_args.append(result_json)  # p_result_json (OUT)
+                cursor.callproc('developer.discover_objects_unified', proc_args)
             else:
-                cursor.callproc('developer.discover_objects', [
+                proc_args = [
                     query,      # p_query
                     k,          # p_k
                     k0,         # p_k0
                     n,          # p_n
                     cols_per_obj,  # p_cols_per_obj
                     alpha,      # p_alpha
-                    result_json # p_result_json (OUT)
-                ])
+                ]
+                if use_hybrid:
+                    proc_args.extend([
+                        search_scorer,
+                        search_fusion,
+                        vector_search_mode,
+                        vector_aggregator,
+                        vector_score_weight,
+                        vector_rank_penalty,
+                        effective_text_contains,
+                        text_score_weight,
+                        text_rank_penalty,
+                    ])
+                proc_args.append(result_json)  # p_result_json (OUT)
+                cursor.callproc('developer.discover_objects', proc_args)
 
             end_time = time.perf_counter()
             execution_time_ms = (end_time - start_time) * 1000
@@ -820,7 +948,13 @@ class OracleManager:
 
     def infer_objects_unified(self, query: str, k: int = 10, n: Optional[int] = None,
                               cols_per_obj: int = 5,
-                              score_threshold: float = 0.60) -> Tuple[Optional[List[DiscoveredObject]], float]:
+                              score_threshold: float = 0.60,
+                              search_type: str = 'vector',
+                              search_scorer: str = 'RSF', search_fusion: str = 'UNION',
+                              vector_search_mode: str = 'DOCUMENT', vector_aggregator: str = 'MAX',
+                              vector_score_weight: float = 1.0, vector_rank_penalty: float = 5.0,
+                              text_contains: Optional[str] = None,
+                              text_score_weight: float = 10.0, text_rank_penalty: float = 1.0) -> Tuple[Optional[List[DiscoveredObject]], float]:
         """Infer objects using developer.discover_objects_unified()."""
         return self.discover_objects(
             query=query,
@@ -828,7 +962,17 @@ class OracleManager:
             n=n,
             cols_per_obj=cols_per_obj,
             discovery_mode='unified',
-            unified_score_threshold=score_threshold
+            unified_score_threshold=score_threshold,
+            search_type=search_type,
+            search_scorer=search_scorer,
+            search_fusion=search_fusion,
+            vector_search_mode=vector_search_mode,
+            vector_aggregator=vector_aggregator,
+            vector_score_weight=vector_score_weight,
+            vector_rank_penalty=vector_rank_penalty,
+            text_contains=text_contains,
+            text_score_weight=text_score_weight,
+            text_rank_penalty=text_rank_penalty,
         )
 
     def drop_user(self, username: str) -> bool:
@@ -2492,6 +2636,16 @@ def evaluate_questions_for_db(oracle_mgr: OracleManager, db_id: str,
                     n=cfg.n,
                     cols_per_obj=cfg.cols_per_obj,
                     score_threshold=cfg.unified_score_threshold,
+                    search_type=cfg.search_type,
+                    search_scorer=cfg.search_scorer,
+                    search_fusion=cfg.search_fusion,
+                    vector_search_mode=cfg.vector_search_mode,
+                    vector_aggregator=cfg.vector_aggregator,
+                    vector_score_weight=cfg.vector_score_weight,
+                    vector_rank_penalty=cfg.vector_rank_penalty,
+                    text_contains=cfg.text_contains,
+                    text_score_weight=cfg.text_score_weight,
+                    text_rank_penalty=cfg.text_rank_penalty,
                 )
             else:
                 discovered, exec_time = oracle_mgr.discover_objects(
@@ -2506,6 +2660,16 @@ def evaluate_questions_for_db(oracle_mgr: OracleManager, db_id: str,
                     alpha=cfg.alpha,
                     parallel_alpha=cfg.parallel_alpha,
                     unified_score_threshold=cfg.unified_score_threshold,
+                    search_type=cfg.search_type,
+                    search_scorer=cfg.search_scorer,
+                    search_fusion=cfg.search_fusion,
+                    vector_search_mode=cfg.vector_search_mode,
+                    vector_aggregator=cfg.vector_aggregator,
+                    vector_score_weight=cfg.vector_score_weight,
+                    vector_rank_penalty=cfg.vector_rank_penalty,
+                    text_contains=cfg.text_contains,
+                    text_score_weight=cfg.text_score_weight,
+                    text_rank_penalty=cfg.text_rank_penalty,
                 )
 
             result.execution_time_ms = exec_time
@@ -2697,7 +2861,9 @@ def build_discovery_config(args: argparse.Namespace) -> DiscoveryConfig:
 
     if args.discover_config_json:
         raw = json.loads(args.discover_config_json)
-        for key in ['k', 'k0', 'n', 'm', 'cols_per_obj', 'alpha', 'parallel_alpha', 'unified_score_threshold']:
+        for key in ['k', 'k0', 'n', 'm', 'cols_per_obj', 'alpha', 'parallel_alpha', 'unified_score_threshold',
+                    'search_type', 'search_scorer', 'search_fusion', 'vector_search_mode', 'vector_aggregator',
+                    'vector_score_weight', 'vector_rank_penalty', 'text_contains', 'text_score_weight', 'text_rank_penalty']:
             if key in raw:
                 setattr(cfg, key, raw[key])
 
@@ -2717,6 +2883,26 @@ def build_discovery_config(args: argparse.Namespace) -> DiscoveryConfig:
         cfg.parallel_alpha = args.discover_parallel_alpha
     if args.discover_unified_score_threshold is not None:
         cfg.unified_score_threshold = args.discover_unified_score_threshold
+
+    cfg.search_type = args.search_type
+    if args.discover_search_scorer is not None:
+        cfg.search_scorer = args.discover_search_scorer
+    if args.discover_search_fusion is not None:
+        cfg.search_fusion = args.discover_search_fusion
+    if args.discover_vector_search_mode is not None:
+        cfg.vector_search_mode = args.discover_vector_search_mode
+    if args.discover_vector_aggregator is not None:
+        cfg.vector_aggregator = args.discover_vector_aggregator
+    if args.discover_vector_score_weight is not None:
+        cfg.vector_score_weight = args.discover_vector_score_weight
+    if args.discover_vector_rank_penalty is not None:
+        cfg.vector_rank_penalty = args.discover_vector_rank_penalty
+    if args.discover_text_contains is not None:
+        cfg.text_contains = args.discover_text_contains
+    if args.discover_text_score_weight is not None:
+        cfg.text_score_weight = args.discover_text_score_weight
+    if args.discover_text_rank_penalty is not None:
+        cfg.text_rank_penalty = args.discover_text_rank_penalty
 
     return cfg
 
@@ -2817,6 +3003,12 @@ def main():
         default='sequential',
         help='Discovery mode: sequential, parallel, or unified (default: sequential)'
     )
+    parser.add_argument(
+        '--search-type',
+        choices=['vector', 'hybrid'],
+        default='vector',
+        help='Search request style sent to developer package (default: vector). Use hybrid to include vector+keyword fields.'
+    )
 
     discover_group = parser.add_argument_group('Discovery settings')
     discover_group.add_argument(
@@ -2832,6 +3024,15 @@ def main():
     discover_group.add_argument('--discover-alpha', type=float, default=None, help='Sequential score blend alpha')
     discover_group.add_argument('--discover-parallel-alpha', type=float, default=None, help='Parallel score blend alpha')
     discover_group.add_argument('--discover-unified-score-threshold', type=float, default=None, help='Unified mode score threshold [0,1]')
+    discover_group.add_argument('--discover-search-scorer', type=str, default=None, help='Hybrid search_scorer (e.g. RSF, RRF, WRRF)')
+    discover_group.add_argument('--discover-search-fusion', type=str, default=None, help='Hybrid search_fusion (e.g. UNION, INTERSECT, RERANK)')
+    discover_group.add_argument('--discover-vector-search-mode', type=str, default=None, help='Hybrid vector.search_mode (DOCUMENT or CHUNK)')
+    discover_group.add_argument('--discover-vector-aggregator', type=str, default=None, help='Hybrid vector.aggregator (e.g. MAX, AVG)')
+    discover_group.add_argument('--discover-vector-score-weight', type=float, default=None, help='Hybrid vector.score_weight')
+    discover_group.add_argument('--discover-vector-rank-penalty', type=float, default=None, help='Hybrid vector.rank_penalty')
+    discover_group.add_argument('--discover-text-contains', type=str, default=None, help='Hybrid text.contains override; auto-generated from query when omitted')
+    discover_group.add_argument('--discover-text-score-weight', type=float, default=None, help='Hybrid text.score_weight')
+    discover_group.add_argument('--discover-text-rank-penalty', type=float, default=None, help='Hybrid text.rank_penalty')
 
     args = parser.parse_args()
 
@@ -2965,6 +3166,16 @@ def main():
             'single_user_mode': args.single_user_mode,
             'single_user_name': args.single_user_name if args.single_user_mode else 'n/a',
             'mode': args.mode,
+            'search_type': discover_cfg.search_type,
+            'discover_search_scorer': discover_cfg.search_scorer,
+            'discover_search_fusion': discover_cfg.search_fusion,
+            'discover_vector_search_mode': discover_cfg.vector_search_mode,
+            'discover_vector_aggregator': discover_cfg.vector_aggregator,
+            'discover_vector_score_weight': discover_cfg.vector_score_weight,
+            'discover_vector_rank_penalty': discover_cfg.vector_rank_penalty,
+            'discover_text_contains': discover_cfg.text_contains or 'auto',
+            'discover_text_score_weight': discover_cfg.text_score_weight,
+            'discover_text_rank_penalty': discover_cfg.text_rank_penalty,
             'timestamp': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
         }
 


### PR DESCRIPTION
### Motivation
- Enable a richer hybrid discovery request shape that combines vector and keyword/text controls and let the runner auto-generate `text.contains` keywords from NL queries when users choose the hybrid mode.
- Surface the new tuning knobs in CLI/docs so users can exercise scorer/fusion/vector/text settings end-to-end.
- Wire the Python runner to pass hybrid arguments to the PL/SQL discovery procedures when requested.

### Description
- Extended the PL/SQL package (`index_creation.sql`) by adding hybrid parameters to `discover_objects`, `discover_objects_parallel`, and `discover_objects_unified`, and added `apply_hybrid_search_params` to build the JSON request used by `DBMS_HYBRID_VECTOR.SEARCH`.
- Enhanced the Python runner (`run_hybrid_search_evaluation.py`) with NLTK-aware auto-keyword extraction via `build_text_contains_from_query`, added `DiscoveryConfig` fields for hybrid knobs, introduced a `--search-type` CLI (`vector|hybrid`), and added many `--discover-*` flags to control hybrid scorer/fusion/vector/text parameters.
- Updated the runner to compute an `effective_text_contains` (auto-generated when omitted and `--search-type hybrid`) and to append hybrid args to PL/SQL calls only when hybrid mode is active.
- Documentation updates: added `--search-type`, hybrid tuning flags, and the NLTK auto-generation note to `README.md` and `HYBRID_SEARCH_EVALUATION.md`.
- Added `nltk>=3.8` to `requirements.txt` and implemented a robust fallback tokenization/stopword path when NLTK or resources are unavailable.
