### PR TITLE
Create only needed hybrid indexes and support relative --html output paths

### DIFF
--- a/index_creation.sql
+++ b/index_creation.sql
@@ -182,7 +182,9 @@ CREATE OR REPLACE PACKAGE developer AUTHID CURRENT_USER AS
     p_model_dir   IN VARCHAR2 DEFAULT 'ONNX_IMPORT',
     p_model_file  IN VARCHAR2 DEFAULT 'MiniLM.onnx',
     p_model_name  IN VARCHAR2 DEFAULT 'ALL_MINILM_L6',
-    p_vectorizer  IN VARCHAR2 DEFAULT 'VEC_MINILM_IVF'
+    p_vectorizer  IN VARCHAR2 DEFAULT 'VEC_MINILM_IVF',
+    p_create_obj_col_indexes IN BOOLEAN DEFAULT TRUE,
+    p_create_uni_index       IN BOOLEAN DEFAULT TRUE
   );
 
 -------------------------------------------------------------------------------
@@ -538,7 +540,9 @@ CREATE OR REPLACE PACKAGE BODY developer AS
     p_model_dir   IN VARCHAR2 DEFAULT 'ONNX_IMPORT',
     p_model_file  IN VARCHAR2 DEFAULT 'MiniLM.onnx',
     p_model_name  IN VARCHAR2 DEFAULT 'ALL_MINILM_L6',
-    p_vectorizer  IN VARCHAR2 DEFAULT 'VEC_MINILM_IVF'
+    p_vectorizer  IN VARCHAR2 DEFAULT 'VEC_MINILM_IVF',
+    p_create_obj_col_indexes IN BOOLEAN DEFAULT TRUE,
+    p_create_uni_index       IN BOOLEAN DEFAULT TRUE
   ) IS
     l_params_obj  VARCHAR2(4000);
     l_params_col  VARCHAR2(4000);
@@ -634,39 +638,44 @@ CREATE OR REPLACE PACKAGE BODY developer AS
     ctx_ddl.create_preference('UNI_DISCOVERY_WL', 'BASIC_WORDLIST');
 
     /* 5) Hybrid vector indexes (base column must be text -> DUMMY) */
-    safe_exec('DROP INDEX obj_discovery_hvix');
-    safe_exec('DROP INDEX col_discovery_hvix');
-    safe_exec('DROP INDEX uni_discovery_hvix');
+    IF p_create_obj_col_indexes THEN
+      safe_exec('DROP INDEX obj_discovery_hvix');
+      safe_exec('DROP INDEX col_discovery_hvix');
 
-    l_params_obj :=
-      'VECTORIZER '    || p_vectorizer       || ' ' ||
-      'DATASTORE '     || 'OBJ_DISCOVERY_DS' || ' ' ||
-      'WORDLIST '      || 'OBJ_DISCOVERY_WL' || ' ' ||
-      'SECTION GROUP ' || 'OBJ_DISCOVERY_SG';
+      l_params_obj :=
+        'VECTORIZER '    || p_vectorizer       || ' ' ||
+        'DATASTORE '     || 'OBJ_DISCOVERY_DS' || ' ' ||
+        'WORDLIST '      || 'OBJ_DISCOVERY_WL' || ' ' ||
+        'SECTION GROUP ' || 'OBJ_DISCOVERY_SG';
 
-    EXECUTE IMMEDIATE
-      'CREATE HYBRID VECTOR INDEX obj_discovery_hvix ON all_objects_search_text(dummy) ' ||
-      'PARAMETERS(''' || l_params_obj || ''')';
+      EXECUTE IMMEDIATE
+        'CREATE HYBRID VECTOR INDEX obj_discovery_hvix ON all_objects_search_text(dummy) ' ||
+        'PARAMETERS(''' || l_params_obj || ''')';
 
-    l_params_col :=
-      'VECTORIZER '    || p_vectorizer       || ' ' ||
-      'DATASTORE '     || 'COL_DISCOVERY_DS' || ' ' ||
-      'WORDLIST '      || 'COL_DISCOVERY_WL' || ' ' ||
-      'SECTION GROUP ' || 'COL_DISCOVERY_SG';
+      l_params_col :=
+        'VECTORIZER '    || p_vectorizer       || ' ' ||
+        'DATASTORE '     || 'COL_DISCOVERY_DS' || ' ' ||
+        'WORDLIST '      || 'COL_DISCOVERY_WL' || ' ' ||
+        'SECTION GROUP ' || 'COL_DISCOVERY_SG';
 
-    EXECUTE IMMEDIATE
-      'CREATE HYBRID VECTOR INDEX col_discovery_hvix ON all_cols_search_text(dummy) ' ||
-      'PARAMETERS(''' || l_params_col || ''')';
+      EXECUTE IMMEDIATE
+        'CREATE HYBRID VECTOR INDEX col_discovery_hvix ON all_cols_search_text(dummy) ' ||
+        'PARAMETERS(''' || l_params_col || ''')';
+    END IF;
 
-    l_params_uni :=
-      'VECTORIZER '    || p_vectorizer       || ' ' ||
-      'DATASTORE '     || 'UNI_DISCOVERY_DS' || ' ' ||
-      'WORDLIST '      || 'UNI_DISCOVERY_WL' || ' ' ||
-      'SECTION GROUP ' || 'UNI_DISCOVERY_SG';
+    IF p_create_uni_index THEN
+      safe_exec('DROP INDEX uni_discovery_hvix');
 
-    EXECUTE IMMEDIATE
-      'CREATE HYBRID VECTOR INDEX uni_discovery_hvix ON all_unified_search_text(dummy) ' ||
-      'PARAMETERS(''' || l_params_uni || ''')';
+      l_params_uni :=
+        'VECTORIZER '    || p_vectorizer       || ' ' ||
+        'DATASTORE '     || 'UNI_DISCOVERY_DS' || ' ' ||
+        'WORDLIST '      || 'UNI_DISCOVERY_WL' || ' ' ||
+        'SECTION GROUP ' || 'UNI_DISCOVERY_SG';
+
+      EXECUTE IMMEDIATE
+        'CREATE HYBRID VECTOR INDEX uni_discovery_hvix ON all_unified_search_text(dummy) ' ||
+        'PARAMETERS(''' || l_params_uni || ''')';
+    END IF;
 
   END setup_hybrid_search;
 

--- a/run_hybrid_search_evaluation.py
+++ b/run_hybrid_search_evaluation.py
@@ -775,16 +775,27 @@ class OracleManager:
                 print(f"    Warning: refresh_data failed: {error_str[:200]}")
             return False
 
-    def call_setup_hybrid_search(self) -> bool:
-        """Call developer.setup_hybrid_search() to create indexes."""
+    def call_setup_hybrid_search(self, discovery_mode: str = 'sequential') -> bool:
+        """Call developer.setup_hybrid_search() and create only required indexes."""
         if not self.user_connection:
             return False
 
         try:
             cursor = self.user_connection.cursor()
-            cursor.callproc('developer.setup_hybrid_search')
+            create_obj_col_indexes = discovery_mode in ('sequential', 'parallel')
+            create_uni_index = discovery_mode == 'unified'
+            cursor.callproc(
+                'developer.setup_hybrid_search',
+                keyword_parameters={
+                    'p_create_obj_col_indexes': create_obj_col_indexes,
+                    'p_create_uni_index': create_uni_index,
+                }
+            )
             self.user_connection.commit()
-            print(f"    Called developer.setup_hybrid_search()")
+            print(
+                "    Called developer.setup_hybrid_search() "
+                f"[obj+col={create_obj_col_indexes}, unified={create_uni_index}]"
+            )
             return True
         except oracledb.DatabaseError as e:
             error_str = str(e)
@@ -2562,7 +2573,7 @@ def process_database(oracle_mgr: OracleManager, db_id: str,
     # Step 5: Call refresh_data and setup_hybrid_search (only if package was installed)
     if package_installed:
         refresh_ok = oracle_mgr.call_refresh_data()
-        setup_ok = oracle_mgr.call_setup_hybrid_search()
+        setup_ok = oracle_mgr.call_setup_hybrid_search(discovery_mode)
         if not refresh_ok and not setup_ok:
             print(f"  Note: developer package not available, skipping hybrid search setup")
     else:
@@ -2825,7 +2836,7 @@ def process_databases_single_user(
     package_installed = oracle_mgr.execute_index_creation(index_script)
     if package_installed:
         refresh_ok = oracle_mgr.call_refresh_data()
-        setup_ok = oracle_mgr.call_setup_hybrid_search()
+        setup_ok = oracle_mgr.call_setup_hybrid_search(discovery_mode)
         if not refresh_ok and not setup_ok:
             print("  Note: developer package not available, skipping hybrid search setup")
     else:
@@ -3181,9 +3192,14 @@ def main():
 
         html_content = generate_results_html(all_results, all_summaries, run_params)
 
-        with open(args.html, 'w', encoding='utf-8') as f:
+        html_path = Path(args.html)
+        if not html_path.is_absolute():
+            html_path = Path.cwd() / html_path
+        html_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(html_path, 'w', encoding='utf-8') as f:
             f.write(html_content)
-        print(f"HTML report written to: {args.html}")
+        print(f"HTML report written to: {html_path}")
 
         # Print overall summary
         print(f"\n{'='*60}")
@@ -3211,9 +3227,12 @@ def main():
         start_results_server(html_content, port=args.port)
 
     # Start local server if requested (after DB cleanup)
-    if args.serve and args.html and os.path.isfile(args.html):
-        html_dir = os.path.dirname(os.path.abspath(args.html))
-        start_local_server(html_dir, args.port)
+    if args.serve and args.html:
+        html_path = Path(args.html)
+        if not html_path.is_absolute():
+            html_path = Path.cwd() / html_path
+        if html_path.is_file():
+            start_local_server(str(html_path.parent), args.port)
 
     return 0
 


### PR DESCRIPTION
### Motivation
- The PL/SQL `setup_hybrid_search` always dropped/created all three hybrid indexes even when only one index type was needed, causing unnecessary work and resource usage.
- The evaluation runner wrote the HTML report to a path without ensuring parent directories exist and didn't resolve relative paths, making `--html reports/run1/report.html` fail.

### Description
- Added two optional boolean parameters to `developer.setup_hybrid_search` in `index_creation.sql`: `p_create_obj_col_indexes` and `p_create_uni_index`, and wrapped index DDL in `IF` blocks so only requested indexes are dropped/created. (`index_creation.sql`)
- Updated `OracleManager.call_setup_hybrid_search` signature in `run_hybrid_search_evaluation.py` to accept `discovery_mode`, compute which indexes to create (`obj+col` for `sequential`/`parallel`, `unified` for `unified`) and pass those flags to the PL/SQL procedure via `callproc`. (`run_hybrid_search_evaluation.py`)
- Propagated `discovery_mode` into `process_database` and `process_databases_single_user` calls so the correct index set is created for each run mode. (`run_hybrid_search_evaluation.py`)
- Made HTML output handling robust by resolving `--html` into an absolute `Path`, creating parent directories with `mkdir(parents=True, exist_ok=True)`, writing to the resolved path, and updating `--serve` handling to use the resolved path directory. (`run_hybrid_search_evaluation.py`)

### Testing
- Validated Python syntax for the modified runner with `python -m py_compile run_hybrid_search_evaluation.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996e32e74f88322b6e42d7ebd2d7c9b)