### PR TITLE
Docs: rename discover score threshold flag and clarify NLTK fallback for hybrid search runner

### DIFF
--- a/HYBRID_SEARCH_EVALUATION.md
+++ b/HYBRID_SEARCH_EVALUATION.md
@@ -197,7 +197,7 @@ You can now provide discovery procedure arguments as a grouped JSON config and/o
 | `--discover-cols-per-obj` | 5 | Max columns attached per object |
 | `--discover-alpha` | 0.65 | Sequential rerank blend alpha (`p_alpha`) |
 | `--discover-parallel-alpha` | 0.60 | Parallel rerank blend alpha (`p_alpha`) |
-| `--discover-unified-score-threshold` | 0.60 | Unified mode score threshold |
+| `--discover-score-threshold` | 60.0 | Unified mode score threshold (`[0,100]`) |
 | `--discover-search-scorer` | RSF | Hybrid `search_scorer` |
 | `--discover-search-fusion` | UNION | Hybrid `search_fusion` |
 | `--discover-vector-search-mode` | DOCUMENT | Hybrid `vector.search_mode` |
@@ -209,8 +209,10 @@ You can now provide discovery procedure arguments as a grouped JSON config and/o
 | `--discover-text-rank-penalty` | 1 | Hybrid `text.rank_penalty` |
 
 `--discover-text-contains` auto behavior: when `--search-type hybrid` is used and this
-flag is omitted, the runner generates keywords from the query text via Python NLTK
-(`word_tokenize`, English stopwords filtering, `isalpha`, dedupe, joined with `OR`).
+flag is omitted, the runner generates keywords from the query text in Python. It
+uses NLTK (`word_tokenize` + English stopwords filtering + `isalpha` + dedupe, joined
+with `OR`) when available, and falls back to built-in regex/stopword filtering when NLTK
+resources are unavailable.
 
 Override precedence: explicit CLI flags > `--discover-config-json` > built-in defaults.
 

--- a/README.md
+++ b/README.md
@@ -311,8 +311,9 @@ The runner now supports two request styles:
 - `--search-type hybrid`: sends hybrid vector+keyword arguments (scorer/fusion/vector/text knobs)
 
 When running with `--search-type hybrid`, if `--discover-text-contains` is not provided,
-the runner auto-generates `text.contains` keywords from the NL query in Python using NLTK
-tokenization + stopword filtering and joins terms with `OR`.
+the runner auto-generates `text.contains` keywords from the NL query in Python and joins
+terms with `OR`. It uses NLTK tokenization + stopword filtering when available, and
+falls back to built-in regex/stopword filtering when NLTK resources are unavailable.
 
 Example with parallel mode and grouped discovery config:
 
@@ -326,6 +327,7 @@ python run_hybrid_search_evaluation.py \
 
 Optional hybrid tuning flags:
 
+- `--discover-score-threshold`
 - `--discover-search-scorer`
 - `--discover-search-fusion`
 - `--discover-vector-search-mode`


### PR DESCRIPTION
### Motivation
- Standardize and clarify hybrid discovery configuration by renaming the unified score threshold flag to a simpler name and documenting keyword-generation fallback behavior.

### Description
- Update `HYBRID_SEARCH_EVALUATION.md` and `README.md` to replace `--discover-unified-score-threshold` with `--discover-score-threshold` and set its default to `60.0` with `[0,100]` semantics; add `--discover-score-threshold` to the README's hybrid tuning list and clarify that auto-generated `text.contains` keywords use NLTK when available and fall back to built-in regex/stopword filtering when NLTK resources are unavailable.

### Testing
- Documentation-only change; no automated tests were modified or executed as part of this update.
