### PR TITLE
Docs: Add OCI LLM support, results auto-routing, and expanded hybrid-eval metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,27 @@ python scripts/add_dev_questions_metadata.py <input_dev.json> [output_dev.json] 
 Key options:
 
 - `--method`: `rule_based` (default) or `llm`
-- `--llm-provider`: `openai_compat` (default), `openrouter`, `groq`, or `ollama`
+- `--llm-provider`: `openai_compat` (default), `openrouter`, `groq`, `ollama`, or `oci`
 - `--llm-model`: model name (e.g., `gpt-4o-mini`, `qwen2.5:3b`)
 - `--llm-base-url`: custom API base URL
 - `--llm-api-key`: API key for `openai_compat` provider
 - `--llm-site-url`: optional OpenRouter `HTTP-Referer` header value
 - `--llm-app-name`: optional OpenRouter `X-Title` header value
-- `--llm-batch-size`: questions per LLM request for OpenAI-compatible providers (default `35`)
+- `--llm-batch-size`: questions per LLM request for OpenAI-compatible providers (default `1`)
+- `--output-format`: `json` (default) or `jsonl`
+- `--test-mode` / `--test-limit`: run on only the first N questions
+- `--test-llm` / `--test-sql`: smoke test one SQL prompt and exit
+
+OCI-only options (`--llm-provider oci`):
+
+- `--oci-compartment-id`
+- `--oci-model-id`
+- `--oci-endpoint`
+- `--oci-config-profile` (default `DEFAULT`)
+- `--oci-config-file` (default `~/.oci/config`)
+- `--oci-temperature` (default `0.0`)
+- `--oci-max-tokens` (default `600`)
+- `--oci-top-p` (default `0.75`)
 
 ## Using OpenRouter
 
@@ -247,7 +261,7 @@ Notes:
 - Default Groq-compatible base URL is `https://api.groq.com/openai/v1`.
 - Groq provider uses the Groq Python SDK (`Groq(...).chat.completions.create(...)`) with batched prompts.
 - You can change endpoint with `--llm-base-url` if needed.
-- For OpenAI-compatible providers (`openai_compat`, `openrouter`, `groq`), questions are sent in batches (default 35 per request) instead of one-by-one.
+- For OpenAI-compatible providers (`openai_compat`, `openrouter`, `groq`), questions are sent in batches (default 1 per request) instead of one-by-one.
 
 ## Using Ollama with Local Open-Source Models
 
@@ -289,6 +303,20 @@ Notes:
 - If Ollama is not reachable or the model output is invalid, the script automatically falls back to `rule_based` extraction and continues.
 - For higher accuracy on complex SQL, try a larger model (e.g., 7B/8B+).
 - No OpenAI API key is needed when using `--llm-provider ollama`.
+
+## Using OCI Generative AI
+
+Use `--method llm --llm-provider oci` to run extraction through OCI Generative AI Inference.
+
+```bash
+python scripts/add_dev_questions_metadata.py \
+  data/questions/dev_original.json data/questions/dev_with_metadata.json \
+  --method llm \
+  --llm-provider oci \
+  --oci-compartment-id "ocid1.compartment.oc1..example" \
+  --oci-model-id "ocid1.generativeaimodel.oc1..example" \
+  --oci-endpoint "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+```
 
 ## Requirements
 
@@ -338,4 +366,13 @@ Optional hybrid tuning flags:
 - `--discover-text-score-weight`
 - `--discover-text-rank-penalty`
 
-The generated HTML/CSV reports include additional @K metrics (Recall, Precision, F1) for both table and column evaluation.
+Output paths are now auto-routed under `results/` by default:
+
+- CSV details: `results/csv/...`
+- Summary CSV: `results/summary/...`
+- HTML report: `results/html/...`
+- Live logs: `results/logs/run_YYYYMMDD_HHMMSS.log`
+
+You can override the root with `--results-root`, and still pass explicit file paths via `--output`, `--summary`, `--html`, and `--log-file`.
+
+The generated HTML/CSV reports include additional @K metrics, including Table Precision@K and Column Recall@K variants.

--- a/docs/HYBRID_SEARCH_EVALUATION.md
+++ b/docs/HYBRID_SEARCH_EVALUATION.md
@@ -220,17 +220,19 @@ Then open `http://localhost:8000/report.html` in your browser.
 | Argument | Short | Default | Description |
 |----------|-------|---------|-------------|
 | `--connection-string` | `-c` | *required* | Oracle connection string |
-| `--ddl-dir` | `-d` | `data/oracle_ddl` | Directory containing DDL folders |
-| `--metadata-file` | `-m` | `data/questions/dev_with_metadata.json` | Questions metadata file |
+| `--ddl-dir` | `-d` | `data/oracle_BIRD_train` | Directory containing DDL folders |
+| `--metadata-file` | `-m` | `data/BIRD_questions/train_nl2sql.json` | Questions metadata file |
 | `--index-script` | `-i` | `sql/index_creation.sql` | Hybrid search package script |
-| `--output` | `-o` | `hybrid_search_evaluation_results.csv` | Results CSV file |
-| `--summary` | `-s` | `hybrid_search_evaluation_summary.csv` | Summary CSV file |
+| `--output` | `-o` | auto (`results/csv/...`) | Results CSV file |
+| `--summary` | `-s` | auto (`results/summary/...`) | Summary CSV file |
 | `--databases` | `-db` | all | Specific databases to process |
 | `--test` | `-t` | false | Run in test mode |
 | `--max-questions` | `-q` | all | Max questions per database |
 | `--max-databases` | `-n` | all | Max databases to process |
 | `--output-source` | `-f` | `csv` | Primary output source: `csv` or `browser` |
-| `--html` | | `report.html` | Output HTML report file path |
+| `--html` | | auto (`results/html/...`) | Output HTML report file path |
+| `--results-root` | | `results` | Root folder for auto-routed outputs |
+| `--log-file` | | auto (`results/logs/run_*.log`) | Log file path for live run output |
 | `--serve` | | false | Start a local HTTP server to view the HTML report |
 | `--port` | | 8000 | Port for the local HTTP server |
 | `--single-user-mode` | | false | Load all selected schemas into one Oracle user and run all queries there |
@@ -303,6 +305,16 @@ Per-query detailed results:
 | `table_recall_at_3` | Fraction of expected tables in top-3 |
 | `table_recall_at_5` | Fraction of expected tables in top-5 |
 | `table_recall_at_10` | Fraction of expected tables in top-10 |
+| **Table Precision@K (Fraction)** | Of top-K returned tables, how many were expected |
+| `table_precision_at_1` | Precision among top-1 table |
+| `table_precision_at_3` | Precision among top-3 tables |
+| `table_precision_at_5` | Precision among top-5 tables |
+| `table_precision_at_k` | Precision among top-K tables (`K = --discover-k`) |
+| **Column Recall@K (Fraction)** | Fraction of expected columns recovered in top-K context |
+| `column_recall_at_1` | Column recall at top-1 context |
+| `column_recall_at_3` | Column recall at top-3 context |
+| `column_recall_at_5` | Column recall at top-5 context |
+| `column_recall_at_k` | Column recall at top-K context (`K = --discover-k`) |
 | **Advanced Metrics** | |
 | `table_mrr` | Mean Reciprocal Rank for tables |
 | `table_jaccard` | Jaccard similarity for tables |
@@ -339,6 +351,16 @@ Per-database aggregated metrics:
 | `avg_table_recall_at_3` | Average Recall@3 for tables |
 | `avg_table_recall_at_5` | Average Recall@5 for tables |
 | `avg_table_recall_at_10` | Average Recall@10 for tables |
+| **Table Precision@K Averages** | |
+| `avg_table_precision_at_1` | Average Table Precision@1 |
+| `avg_table_precision_at_3` | Average Table Precision@3 |
+| `avg_table_precision_at_5` | Average Table Precision@5 |
+| `avg_table_precision_at_k` | Average Table Precision@K |
+| **Column Recall@K Averages** | |
+| `avg_column_recall_at_1` | Average Column Recall@1 |
+| `avg_column_recall_at_3` | Average Column Recall@3 |
+| `avg_column_recall_at_5` | Average Column Recall@5 |
+| `avg_column_recall_at_k` | Average Column Recall@K |
 | **Advanced Metrics** | |
 | `avg_table_mrr` | Average MRR for tables |
 | `avg_table_jaccard` | Average Jaccard similarity |
@@ -350,7 +372,7 @@ Per-database aggregated metrics:
 
 ### HTML Report
 
-A single HTML file is always generated (default: `report.html`) that contains the same styled and interactive dashboard used by browser mode. The file can be opened directly in any browser or served via a local HTTP server using `--serve`. Use `--html <file>` to change the file name/path.
+A single HTML file is always generated (auto-routed under `results/html/` unless `--html` is provided) that contains the same styled and interactive dashboard used by browser mode. The file can be opened directly in any browser or served via a local HTTP server using `--serve`. Use `--html <file>` to force a custom file name/path.
 
 The **Run Parameters** section in the HTML report includes `index_setup_time_ms`, which is the total time spent running index/package setup for the run (in single-user mode this is the one-time shared setup time).
 


### PR DESCRIPTION
### Motivation

- Bring documentation into alignment with recent script changes that add OCI Generative AI support and additional LLM options. 
- Make the hybrid evaluation runner behaviour and defaults explicit so users can run experiments reproducibly. 
- Surface new output routing and richer @K metrics so results and summaries are easier to locate and interpret.

### Description

- Updated `README.md` to document `scripts/add_dev_questions_metadata.py` changes: added `--llm-provider oci` and OCI-specific CLI flags, `--output-format`, `--test-mode`/`--test-limit`, `--test-llm`/`--test-sql`, and corrected the OpenAI-compatible batching default to `1` (document only). 
- Added an OCI usage example to `README.md` showing `--method llm --llm-provider oci` and required OCI flags. 
- Updated `docs/HYBRID_SEARCH_EVALUATION.md` to reflect new defaults and paths (e.g. `--ddl-dir` and `--metadata-file`), and to document auto-routed results under `results/` plus new CLI visibility for `--results-root` and `--log-file`. 
- Expanded the hybrid evaluation metrics documentation to include Table Precision@K and Column Recall@K fields in both per-query results and per-database summaries, and clarified HTML report auto-routing.

### Testing

- Verified CLI surface/help output for the hybrid runner with `python scripts/run_hybrid_search_evaluation.py --help` and confirmed help printed the updated defaults and options (success). 
- Verified CLI surface/help output for the metadata generator with `python scripts/add_dev_questions_metadata.py --help` and confirmed `oci` provider and new flags appeared (success). 
- Reviewed diffs with `git diff -- README.md docs/HYBRID_SEARCH_EVALUATION.md` to ensure intended documentation edits were applied (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84fe6ae408322846fed738509fe16)